### PR TITLE
fixing Id problem in notebooks computing ds

### DIFF
--- a/oqmbt/notebooks/sources_distributed_s/create_sources.ipynb
+++ b/oqmbt/notebooks/sources_distributed_s/create_sources.ipynb
@@ -11,8 +11,10 @@
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "%%html\n",
     "<script>\n",
@@ -69,6 +71,7 @@
     "from openquake.hmtk.seismicity.selector import CatalogueSelector\n",
     "\n",
     "from openquake.hazardlib.scalerel.wc1994 import WC1994\n",
+    "\n",
     "from openquake.hazardlib.tom import PoissonTOM\n",
     "from openquake.hazardlib.pmf import PMF\n",
     "from openquake.hazardlib.geo.nodalplane import NodalPlane \n",
@@ -289,7 +292,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "values = smooth.gaussian(50, 20)\n",
+    "#values = smooth.gaussian(50, 20)\n",
     "values = smooth.multiple_smoothing(smooth_param)\n",
     "print('Max of smoothing:', max(values))"
    ]
@@ -416,6 +419,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# To select a different smoothing buffer value \n",
+    "smoothing_buffer = model.smoothing_buffer\n",
+    "#\n",
     "#\n",
     "# find index of magnitudes above the threshold\n",
     "jjj = numpy.nonzero(numpy.array(mags) > faults_lower_threshold_magnitude)\n",
@@ -454,7 +460,7 @@
     "                                                list(coord[:,0]), \n",
     "                                                list(coord[:,1]), \n",
     "                                                idxs,\n",
-    "                                                15000.0) \n",
+    "                                                smoothing_buffer) \n",
     "            \n",
     "            for tidx in iii:\n",
     "                plt.plot(smooth.mesh.lons[tidx], smooth.mesh.lats[tidx], 'o')\n",
@@ -537,6 +543,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Id of the source is created as:\n",
+    "# \"ds_src_id_iterator\". In this the point sources are related to the area_source with an unique Id by source\n",
+    "\n",
     "nrmls = [] \n",
     "\n",
     "import importlib\n",
@@ -555,7 +564,7 @@
     "        tmfd = EvenlyDiscretizedMFD(src.mfd.min_mag, src.mfd.bin_width, list(mfdpnts[iii, jjj][0]))\n",
     "\n",
     "        points = PointSource(\n",
-    "            source_id='%d' % eee, \n",
+    "            source_id='ds_%s_%d' % (src_id, eee), \n",
     "            name='', \n",
     "            tectonic_region_type=src.tectonic_region_type,\n",
     "            mfd=tmfd, \n",
@@ -608,7 +617,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.5.5"
   }
  },
  "nbformat": 4,

--- a/oqmbt/notebooks/sources_distributed_s/create_sources_no_faults.ipynb
+++ b/oqmbt/notebooks/sources_distributed_s/create_sources_no_faults.ipynb
@@ -8,8 +8,10 @@
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "%%html\n",
     "<script>\n",
@@ -66,6 +68,7 @@
     "from openquake.hmtk.seismicity.selector import CatalogueSelector\n",
     "\n",
     "from openquake.hazardlib.scalerel.wc1994 import WC1994\n",
+    "\n",
     "from openquake.hazardlib.tom import PoissonTOM\n",
     "from openquake.hazardlib.pmf import PMF\n",
     "from openquake.hazardlib.geo.nodalplane import NodalPlane \n",
@@ -373,6 +376,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# the Id of the source is created as:\n",
+    "# \"ds_src_id_iterator\". In this the point sources are related to the area_source with an unique Id by source\n",
+    "\n",
     "model.upper_seismogenic_depth = float(model.upper_seismogenic_depth)\n",
     "model.lower_seismogenic_depth = float(model.lower_seismogenic_depth)\n",
     "\n",
@@ -404,8 +410,8 @@
     "        #\n",
     "        # create the point source\n",
     "        points = PointSource(\n",
-    "            source_id='%d' % eee, \n",
-    "            name='', \n",
+    "            source_id='ds_%s_%d' % (src_id, eee),\n",
+    "            name='%s'%(src_id), \n",
     "            tectonic_region_type=src.tectonic_region_type,\n",
     "            mfd=tmfd, \n",
     "            rupture_mesh_spacing=rupture_mesh_spacing,\n",
@@ -432,7 +438,8 @@
     "model_dir = os.path.join(oqtkp.directory, 'nrml/%s' % (re.sub('\\s','_',model_id)))\n",
     "if not os.path.exists(model_dir):\n",
     "    os.makedirs(model_dir)\n",
-    "model_name = '%s_gridded_seismicity_source_%s.xml' % (model_id, src_id)\n",
+    "#model_name = '%s_gridded_seismicity_source_%s.xml' % (model_id, src_id)\n",
+    "model_name = 'gridded_seismicity_source_%s.xml' % (src_id)\n",
     "out_model_name = os.path.join(model_dir, model_name)\n",
     "_ = write_source_model(out_model_name, nrmls, 'Model %s')\n",
     "print('Created %s ' % (out_model_name))"
@@ -455,7 +462,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.4"
+   "version": "3.5.5"
   },
   "toc": {
    "nav_menu": {},


### PR DESCRIPTION
This PR solve the problem with the Id source of the distributed seismicity models.
Id of the source is created as: "ds_src_id_iterator".  In this way the point sources have an ID, related to the area_source but with an unique value by source
