### PR TITLE
Reclass pre1900 shallow

### DIFF
--- a/openquake/mbt/tools/tr/set_subduction_earthquakes.py
+++ b/openquake/mbt/tools/tr/set_subduction_earthquakes.py
@@ -234,12 +234,12 @@ class SetSubductionEarthquakes:
                                                       cat.data['latitude'])])
         #
         # compute the depth of the top of the slab at every epicenter
-        sub_depths = griddata(data, values, (points[:, 0], points[:, 1]),
-                              method='cubic')
+    #    sub_depths = griddata(data, values, (points[:, 0], points[:, 1]),
+    #                          method='cubic')
         #
         # interpolation
-    #    rbfi = Rbf(data[:, 0], data[:, 1], values)
-    #    sub_depths = rbfi(points[:, 0], points[:, 1])
+        rbfi = Rbf(data[:, 0], data[:, 1], values)
+        sub_depths = rbfi(points[:, 0], points[:, 1])
         #
         # saving the distances to a file
         tmps = 'vert_dist_to_slab_{:s}.pkl'.format(self.label)

--- a/openquake/mbt/tools/tr/set_subduction_earthquakes.py
+++ b/openquake/mbt/tools/tr/set_subduction_earthquakes.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-
 import os
 import h5py
 import numpy as np
@@ -104,7 +103,11 @@ class SetSubductionEarthquakes:
         # read the catalogue
         catalogue = get_catalogue(catalogue_filename)
         neq = len(catalogue.data['longitude'])
-        treg = np.full((neq), False, dtype=bool)
+        f = h5py.File(treg_filename, "a")
+        if self.label in f.keys():
+            treg = f[self.label]
+        else:
+            treg = np.full((neq), False, dtype=bool)
         #
         # create the spatial index
         sidx = get_rtree_index(catalogue)
@@ -231,12 +234,12 @@ class SetSubductionEarthquakes:
                                                       cat.data['latitude'])])
         #
         # compute the depth of the top of the slab at every epicenter
-        # sub_depths = griddata(data, values, (points[:, 0], points[:, 1]),
-        #                      method='cubic')
+        sub_depths = griddata(data, values, (points[:, 0], points[:, 1]),
+                              method='cubic')
         #
         # interpolation
-        rbfi = Rbf(data[:, 0], data[:, 1], values)
-        sub_depths = rbfi(points[:, 0], points[:, 1])
+    #    rbfi = Rbf(data[:, 0], data[:, 1], values)
+    #    sub_depths = rbfi(points[:, 0], points[:, 1])
         #
         # saving the distances to a file
         tmps = 'vert_dist_to_slab_{:s}.pkl'.format(self.label)

--- a/openquake/mbt/tools/tr/tectonic_regionalisation.py
+++ b/openquake/mbt/tools/tr/tectonic_regionalisation.py
@@ -47,7 +47,6 @@ def set_crustal(cat, crust, sidx, delta=0):
         iii = list(sidx.nearest((lon, lat, lon, lat), 1))
         #
         # Set the crustal earthquakes
-        print(crust[iii[0], 2]+float(delta), dep)
         if crust[iii[0], 2]+float(delta) > dep:
             treg[idx] = True
         data.append([dep, crust[iii[0], 2]])


### PR DESCRIPTION
Adjusted so that the reclassified earthquakes are added to the existing classification of interface, instead of replacing it

add to ini file:

[interface_1a]
label = interface_1
folder = ../../data/tr02/edges1_if
lower_depth = 80.
low_mag = 7.5 (not mag_low)
upp_year = 1900. (not year_upp)
distance_buffer_above = 100.
distance_buffer_below = 0