### PR TITLE
Fix EvenlyDiscretizedMFD rates

### DIFF
--- a/openquake/mbt/tests/tools/faults_test.py
+++ b/openquake/mbt/tests/tools/faults_test.py
@@ -56,7 +56,7 @@ class TestMomentReleaseRateNonUniformBinEdge(unittest.TestCase):
         self.slip_rate = 0.2
         self.m_low = 6.5
         self.b_gr = 1.0
-        self.bin_width = 1.0
+        self.bin_width = 0.1
         self.rigidity = 32e9
 
         self.moment_accum_rate = (self.area * 1e6 * self.slip_rate * 1e-3
@@ -73,9 +73,19 @@ class TestMomentReleaseRateNonUniformBinEdge(unittest.TestCase):
                                                        self.b_gr,
                                                        self.bin_width)
 
-            mags = _make_range(self.m_low, _M_max, self.bin_width)
+            mags = [mag + self.bin_width / 2. for mag in
+                    _make_range(self.m_low, _M_max, self.bin_width)]
             release_rate = sum([rate * mag_to_mo(mag) 
                                 for rate, mag in zip(bin_rates, mags)])
 
-            self.assertLess(abs(self.moment_accum_rate - release_rate)
-                             / self.moment_accum_rate * 100., 1)
+            release_rate_error = abs((self.moment_accum_rate - release_rate)
+                                     / self.moment_accum_rate * 100)
+
+
+
+            self.assertLess(release_rate_error, 1)
+
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/openquake/mbt/tests/tools/faults_test.py
+++ b/openquake/mbt/tests/tools/faults_test.py
@@ -64,7 +64,7 @@ class TestMomentReleaseRateNonUniformBinEdge(unittest.TestCase):
 
     def test_moment_release_rate(self):
 
-        for _M_max in np.arange(6.501, 8.501, 0.01):
+        for _M_max in numpy.arange(6.501, 8.501, 0.01):
 
             bin_rates = rates_for_double_truncated_mfd(self.area, 
                                                        self.slip_rate,

--- a/openquake/mbt/tests/tools/faults_test.py
+++ b/openquake/mbt/tests/tools/faults_test.py
@@ -84,8 +84,3 @@ class TestMomentReleaseRateNonUniformBinEdge(unittest.TestCase):
 
 
             self.assertLess(release_rate_error, 1)
-
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/openquake/mbt/tests/tools/faults_test.py
+++ b/openquake/mbt/tests/tools/faults_test.py
@@ -75,7 +75,7 @@ class TestMomentReleaseRateNonUniformBinEdge(unittest.TestCase):
 
             mags = _make_range(self.m_low, _M_max, self.bin_width)
             release_rate = sum([rate * mag_to_mo(mag) 
-                                for rate, mag in zip(rates, mags)])
+                                for rate, mag in zip(bin_rates, mags)])
 
             self.assertLess(abs(self.moment_accum_rate - release_rate)
                              / self.moment_accum_rate * 100., 1)

--- a/openquake/mbt/tests/tools/faults_test.py
+++ b/openquake/mbt/tests/tools/faults_test.py
@@ -2,6 +2,8 @@ import numpy
 import unittest
 
 from openquake.mbt.tools.faults import rates_for_double_truncated_mfd
+from openquake.mbt.tools.faults import _make_range
+
 from openquake.mbt.tools.mfd import mag_to_mo
 
 
@@ -37,3 +39,43 @@ class RatesDoubleTruncatedFromSlipTestCase(unittest.TestCase):
 
         # Check that the two values matches
         self.assertLess(abs(computed - expected)/expected*100., 1)
+
+
+
+
+class TestMomentReleaseRateNonUniformBinEdge(unittest.TestCase):
+    """
+    This class tests that moment release rates on the fault equal
+    the moment accumulation rate even if M_max doesn't initally
+    fall on a bin edge
+    """
+
+    def setUp(self):
+
+        self.area = 315
+        self.slip_rate = 0.2
+        self.m_low = 6.5
+        self.b_gr = 1.0
+        self.bin_width = 1.0
+        self.rigidity = 32e9
+
+        self.moment_accum_rate = (self.area * 1e6 * self.slip_rate * 1e-3
+                                  * self.rigidity)
+
+    def test_moment_release_rate(self):
+
+        for _M_max in np.arange(6.501, 8.501, 0.01):
+
+            bin_rates = rates_for_double_truncated_mfd(self.area, 
+                                                       self.slip_rate,
+                                                       self.m_low,
+                                                       _M_max,
+                                                       self.b_gr,
+                                                       self.bin_width)
+
+            mags = _make_range(self.m_low, _M_max, self.bin_width)
+            release_rate = sum([rate * mag_to_mo(mag) 
+                                for rate, mag in zip(rates, mags)])
+
+            self.assertLess(abs(self.moment_accum_rate - release_rate)
+                             / self.moment_accum_rate * 100., 1)

--- a/openquake/mbt/tests/tools/mfd_test.py
+++ b/openquake/mbt/tests/tools/mfd_test.py
@@ -312,4 +312,4 @@ class TestDownsampleMFD(unittest.TestCase):
                              [4.1, 0.45],
                              [4.2, 0.2],
                              ])
-        # self.assertTrue(np.allclose(res, expected))
+        # self.assertTrue(np.allclose(res, expected))            

--- a/openquake/mbt/tools/faults.py
+++ b/openquake/mbt/tools/faults.py
@@ -51,7 +51,7 @@ def get_fault_vertices_3d(fault_trace, upper_seismogenic_depth,
     return all_lons, all_lats, all_deps
 
 
-def _get_rate_above_m_low(seismic_moment, m_low, m_upp, b_gr):
+def _get_rate_above_m_low(seismic_moment, m_low, m_upp, b_gr, a_m=9.05):
     """
     :parameter seismic_moment:
         Seismic moment in Nm
@@ -62,7 +62,6 @@ def _get_rate_above_m_low(seismic_moment, m_low, m_upp, b_gr):
     :parameter b_gr:
         b value of the Gutenberg-Richter relationship
     """
-    a_m = 9.1
     b_m = 1.5
     beta = b_gr * numpy.log(10.)
     x = (-seismic_moment*(b_m*numpy.log(10.) - beta) /

--- a/openquake/mbt/tools/faults.py
+++ b/openquake/mbt/tools/faults.py
@@ -113,7 +113,7 @@ def rates_for_double_truncated_mfd(area, slip_rate, m_low, m_upp, b_gr,
     moment_from_slip = (rigidity * area_m2 * slip_m)
 
     # Round m_upp to bin edge
-    m_upp = _round_M_max(m_upp, m_low, bin_width, tol=bin_width/100.)
+    m_upp = _round_m_max(m_upp, m_low, bin_width, tol=bin_width/100.)
 
     # Compute total rate
     rate_above = _get_rate_above_m_low(moment_from_slip, m_low, m_upp, b_gr)
@@ -130,17 +130,17 @@ def rates_for_double_truncated_mfd(area, slip_rate, m_low, m_upp, b_gr,
     return rrr
 
 
-def _round_M_max(M_max, M_min, bin_size, tol=0.0001):
+def _round_m_max(m_max, m_min, bin_size, tol=0.0001):
     """
-    Rounds `M_max` up to `M_min` plus an integer multiple of `bin_size`.
+    Rounds `m_max` up to `m_min` plus an integer multiple of `bin_size`.
     
-    :param M_max:
+    :param m_max:
         Initial value for maximum earthquake magnitude.
         
-    :type M_max:
+    :type m_max:
         float
         
-    :param M_min:
+    :param m_min:
         Minimum earthquake magnitude.
     
     :param bin_size:
@@ -151,7 +151,7 @@ def _round_M_max(M_max, M_min, bin_size, tol=0.0001):
         float
         
     :param tol:
-        Tolerance for deciding whether `M_max` falls on a bin edge.
+        Tolerance for deciding whether `m_max` falls on a bin edge.
         Should be larger than the floating-point precision but much
         smaller than the bin_size.
         
@@ -159,28 +159,28 @@ def _round_M_max(M_max, M_min, bin_size, tol=0.0001):
         float
         
     :returns:
-        New (rounded-up) M_max.
+        New (rounded-up) m_max.
         
     :rtype:
         float
     """
     
-    M_diff = M_max - M_min
-    if M_diff > 0:
-        n_bins = M_diff // bin_size
-        bin_remainder = M_diff % bin_size
+    m_diff = m_max - m_min
+    if m_diff > 0:
+        n_bins = m_diff // bin_size
+        bin_remainder = m_diff % bin_size
     
         if bin_remainder < tol:
             n_bins = n_bins
         else:
             n_bins = n_bins + 1
     
-        new_M_max = M_min + n_bins * bin_size
+        new_m_max = m_min + n_bins * bin_size
         
     else:
-        new_M_max = M_max
+        new_m_max = m_max
     
-    return new_M_max
+    return new_m_max
 
 
 def _make_range(start, stop, step, tol=0.0001):

--- a/openquake/mbt/tools/mfd.py
+++ b/openquake/mbt/tools/mfd.py
@@ -75,24 +75,24 @@ class GammaMFD(object):
         return phi
 
 
-def mag_to_mo(mag):
+def mag_to_mo(mag, c=9.05):
     """
     Scalar moment [in Nm] from moment magnitude
 
     :return:
         The computed scalar seismic moment
     """
-    return 10**(1.5*mag+9.1)
+    return 10**(1.5 * mag + c)
 
 
-def mo_to_mag(mo):
+def mo_to_mag(mo, c=9.05):
     """
     From moment magnitude to scalar moment [in Nm]
 
     :return:
         The computed magnitude
     """
-    return (np.log10(mo)-9.1)/1.5
+    return (np.log10(mo) - c) / 1.5
 
 
 def interpolate_ccumul(mfd, threshold):
@@ -163,7 +163,7 @@ def get_cumulative(mfd):
     return mags, cml[::-1]
 
 
-def get_moment_from_mfd(mfd, threshold=-1):
+def get_moment_from_mfd(mfd, threshold=-1, c=9.05):
     """
     This computes the total scalar seismic moment released per year by a
     source
@@ -182,7 +182,7 @@ def get_moment_from_mfd(mfd, threshold=-1):
         mo_tot = 0.0
         for occ in occ_list:
             if occ[0] > threshold:
-                mo_tot += occ[1] * 10.**(1.5*occ[0] + 9.1)
+                mo_tot += occ[1] * 10.**(1.5*occ[0] + c)
     else:
         raise ValueError('Unrecognised MFD type: %s' % type(mfd))
     return mo_tot

--- a/openquake/mbt/tools/mfd.py
+++ b/openquake/mbt/tools/mfd.py
@@ -182,7 +182,7 @@ def get_moment_from_mfd(mfd, threshold=-1):
         mo_tot = 0.0
         for occ in occ_list:
             if occ[0] > threshold:
-                mo_tot += occ[1] * 10.**(1.5*occ[0] + 9.05)
+                mo_tot += occ[1] * 10.**(1.5*occ[0] + 9.1)
     else:
         raise ValueError('Unrecognised MFD type: %s' % type(mfd))
     return mo_tot


### PR DESCRIPTION
When M_max doesn't fall on a bin edge, the earthquake occurrence rates predicted by the `rates_for_double_truncated_mfd` are not correct (they are typically too high, by a factor of 2-100).

This is described in more detail in #75.

This PR fixes that (mostly by rounding M_max to the next bin edge), and introduces a new unittest that loops through a vector of M_max and tests that the moment release rates stay invariant to M_max.