### PR TITLE
bug fix so that YC1985 is used to make mfds when specified

### DIFF
--- a/openquake/mbt/tools/fault_modeler/fault_modeling_utils.py
+++ b/openquake/mbt/tools/fault_modeler/fault_modeling_utils.py
@@ -17,10 +17,9 @@
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors: Julio Garcia, Richard Styron, Valerio Poggi
-# Last modify: 10/09/2018
+# Last modify: 09/04/2019
 
 # -----------------------------------------------------------------------------
-
 import warnings
 import numpy as np
 from copy import deepcopy
@@ -2543,7 +2542,7 @@ def calc_mfd_from_fault_params(fault_dict,
         tuple
     """
 
-    if mfd_type is None:
+    if True:
         mfd_type = fetch_param_val(fault_dict, 'mfd_type', defaults=defaults,
                                    param_map=param_map)
 

--- a/openquake/mbt/tools/fault_modeler/fault_source_modeler.py
+++ b/openquake/mbt/tools/fault_modeler/fault_source_modeler.py
@@ -18,10 +18,9 @@
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 #
 # Authors: Julio Garcia, Richard Styron, Valerio Poggi
-# Last modify: 10/09/2018
+# Last modify: 09/04/2019
 
 # -----------------------------------------------------------------------------
-
 import sys
 import ast
 import json


### PR DESCRIPTION
small edits to the fault modeler so it correctly uses the Youngs and Coppersmith MFD when specified in the configs