### PR TITLE
Bump GDAL requirement to 2.4.1

### DIFF
--- a/requirements-py36-linux64.txt
+++ b/requirements-py36-linux64.txt
@@ -4,5 +4,5 @@
 
 # GEM Mirror
 http://cdn.ftp.openquake.org/wheelhouse/linux/py36/pyproj-1.9.5.1-cp36-cp36m-manylinux1_x86_64.whl
-http://cdn.ftp.openquake.org/wheelhouse/linux/py36/GDAL-2.2.4-cp36-cp36m-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py36/GDAL-2.4.1-cp36-cp36m-manylinux1_x86_64.whl
 http://cdn.ftp.openquake.org/wheelhouse/linux/py36/Rtree-0.8.3-cp36-cp36m-manylinux1_x86_64.whl

--- a/requirements-py36-macos.txt
+++ b/requirements-py36-macos.txt
@@ -3,6 +3,6 @@
 # !! must update pip first! so wheels will be used !!
 
 # GEM Mirror
-http://cdn.ftp.openquake.org/wheelhouse/macos/py36/GDAL-2.2.4-cp36-cp36m-macosx_10_6_intel.whl
 http://cdn.ftp.openquake.org/wheelhouse/macos/py36/pyproj-1.9.5.1-cp36-cp36m-macosx_10_6_intel.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py36/GDAL-2.4.1-cp36-cp36m-macosx_10_9_x86_64.whl  
 http://cdn.ftp.openquake.org/wheelhouse/macos/py36/Rtree-0.8.3-cp36-cp36m-macosx_10_6_intel.whl


### PR DESCRIPTION
We bumped GDAL version in our wheelhouse to 2.4.1 because of Crave