### PR TITLE
added m_max as an attribute of src_fault

### DIFF
--- a/openquake/mbt/notebooks/sources_shallow_fault/mfd_double_truncated_from_slip_rate_SRC.ipynb
+++ b/openquake/mbt/notebooks/sources_shallow_fault/mfd_double_truncated_from_slip_rate_SRC.ipynb
@@ -43,9 +43,7 @@
     "from openquake.mbt.tools.faults import get_rate_above_m_cli\n",
     "from openquake.hazardlib.geo.surface import SimpleFaultSurface\n",
     "from openquake.hazardlib.mfd import EvenlyDiscretizedMFD\n",
-    "from openquake.hazardlib.scalerel.wc1994 import WC1994\n",
-    "from openquake.hazardlib.scalerel.leonard2014 import (Leonard2014_Interplate, \n",
-    "                                                      Leonard2014_SCR)"
+    "from openquake.hazardlib.scalerel.wc1994 import WC1994"
    ]
   },
   {
@@ -81,7 +79,7 @@
    "source": [
     "default_mcli = float(model.faults_lower_threshold_magnitude)\n",
     "bin_width = float(model.mfd_binwidth)\n",
-    "scalerel_name = model.msr\n"
+    "scalerel_name = model.msr"
    ]
   },
   {
@@ -104,7 +102,7 @@
     "import importlib\n",
     "module = importlib.import_module('openquake.hazardlib.scalerel')\n",
     "my_class = getattr(module, scalerel_name)\n",
-    "scalrel = my_class()\n"
+    "scalrel = my_class()"
    ]
   },
   {
@@ -170,7 +168,9 @@
     "        flt_area = surf.get_area()\n",
     "\n",
     "        # Median magnitude\n",
-    "        if hasattr(src, 'm_max') and float(getattr(src, 'm_max')) > 0.0:\n",
+    "        if (hasattr(src, 'mmax') and float(getattr(src, 'mmax')) > 0.0) or \\\n",
+    "           (hasattr(src, 'm_max') and float(getattr(src, 'm_max')) > 0.0):    \n",
+    "            \n",
     "            mmax = float(getattr(src, 'm_max'))\n",
     "            print('Maximum magnitude (from input)               : %.2f' % (mmax))\n",
     "        else:\n",

--- a/openquake/mbt/notebooks/sources_shallow_fault/mfd_double_truncated_from_slip_rate_SRC.ipynb
+++ b/openquake/mbt/notebooks/sources_shallow_fault/mfd_double_truncated_from_slip_rate_SRC.ipynb
@@ -43,7 +43,9 @@
     "from openquake.mbt.tools.faults import get_rate_above_m_cli\n",
     "from openquake.hazardlib.geo.surface import SimpleFaultSurface\n",
     "from openquake.hazardlib.mfd import EvenlyDiscretizedMFD\n",
-    "from openquake.hazardlib.scalerel.wc1994 import WC1994"
+    "from openquake.hazardlib.scalerel.wc1994 import WC1994\n",
+    "from openquake.hazardlib.scalerel.leonard2014 import (Leonard2014_Interplate, \n",
+    "                                                      Leonard2014_SCR)"
    ]
   },
   {
@@ -79,7 +81,7 @@
    "source": [
     "default_mcli = float(model.faults_lower_threshold_magnitude)\n",
     "bin_width = float(model.mfd_binwidth)\n",
-    "scalerel_name = model.msr"
+    "scalerel_name = model.msr\n"
    ]
   },
   {
@@ -102,7 +104,7 @@
     "import importlib\n",
     "module = importlib.import_module('openquake.hazardlib.scalerel')\n",
     "my_class = getattr(module, scalerel_name)\n",
-    "scalrel = my_class()"
+    "scalrel = my_class()\n"
    ]
   },
   {
@@ -156,6 +158,7 @@
     "            scalerel = getattr(src, 'scalerel')\n",
     "        else:\n",
     "            scalerel = WC1994()\n",
+    "            \n",
     "\n",
     "        # Compute area source\n",
     "        surf = SimpleFaultSurface.from_fault_data(\n",
@@ -167,12 +170,18 @@
     "        flt_area = surf.get_area()\n",
     "\n",
     "        # Median magnitude\n",
-    "        if hasattr(src, 'mmax') and float(getattr(src, 'mmax')) > 0.0:\n",
-    "            mmax = float(getattr(src, 'mmax'))\n",
+    "        if hasattr(src, 'm_max') and float(getattr(src, 'm_max')) > 0.0:\n",
+    "            mmax = float(getattr(src, 'm_max'))\n",
     "            print('Maximum magnitude (from input)               : %.2f' % (mmax))\n",
     "        else:\n",
     "            median_magnitude = scalrel.get_median_mag(flt_area, src.rake)\n",
-    "            std = scalrel.get_std_dev_mag(src.rake)\n",
+    "            # \n",
+    "            if (str(scalerel) == '<Leonard2014_Interplate>' or str(scalerel) == '<Leonard2014_SCR>'):\n",
+    "                # fixed at 0.2 from paper\n",
+    "                std = 0.2\n",
+    "            else:\n",
+    "                std = scalrel.get_std_dev_mag(src.rake)\n",
+    "\n",
     "            mmax = median_magnitude + std * 2\n",
     "            print('Maximum magnitude (from scaling relationship): %.2f' % (mmax))\n",
     "            print('Magnitude Standard Deviation                 : %.2f' % (std))\n",
@@ -215,7 +224,7 @@
     "                src.mfd = None\n",
     "                src.scalerel = None                \n",
     "        else:  \n",
-    "            print('MFD not defined: mag from scaling relationship < m_min + bin_width')\n",
+    "            print('MFD not defined: mag from scaling relationship < m_cli + bin_width')\n",
     "            src.mfd = None\n",
     "            src.scalerel = None\n",
     "\n",

--- a/openquake/mbt/tests/data/tools/data_test_fault_conversion.geojson
+++ b/openquake/mbt/tests/data/tools/data_test_fault_conversion.geojson
@@ -32,7 +32,8 @@
                 "lower_seis_depth": 12.0,
                 "last_movement": null,
                 "reference": "fake",
-                "notes": "blah"
+                "notes": "blah",
+                "m_max": 7.0
             },
             "geometry": {
                 "type": "LineString",

--- a/openquake/mbt/tests/tools/fault_modeler/test_fault_modeling_utils.py
+++ b/openquake/mbt/tests/tools/fault_modeler/test_fault_modeling_utils.py
@@ -182,6 +182,15 @@ class TestModelingUtils(unittest.TestCase):
 
         self.assertTrue(abs((length * 20.) - area) < 0.01)
 
+    def test_get_m_max_from_geojson(self):
+
+        m_max = fmu.get_m_max(self.fault_1,
+                          area_method='simple', width_method='seismo_depth',
+                          width_scaling_relation='Leonard2014_Interplate',
+                          defaults=fmu.defaults, param_map=self.param_map)
+
+        self.assertEqual(m_max, 7.0)
+
     # Rates
     def test_get_net_slip_rate(self):
 
@@ -252,19 +261,18 @@ class TestModelingUtils(unittest.TestCase):
                                                 self.fault_1,
                                                 param_map=self.param_map,
                                                 defaults=fmu.defaults)
-        # mdf_rates values were computed by hand using m_min = 4.0
-        # and m_cli = 6.0 as default values
-        mfd_rates = [(6.05, 0.006316366706615863),
-                     (6.1499999999999995, 0.005017268415937408),
-                     (6.25, 0.0039853579639694565),
-                     (6.35, 0.0031656823562642173),
-                     (6.45, 0.0025145908777491803),
-                     (6.55, 0.0019974105329762706),
-                     (6.65, 0.0015865995826787318),
-                     (6.75, 0.0012602808457234777),
-                     (6.85, 0.0010010766594403568),
-                     (6.95, 0.0007951834557169339),
-                     (7.05, 0.0006316366706616012)]
+        # mdf_rates values were computed by hand using m_min = 4.0,
+        # m_cli = 6.0 and m_max = 7.0 as default values
+        mfd_rates =  [(6.05, 0.007316449031674849),
+                     (6.1499999999999995, 0.005811662043780461),
+                     (6.25, 0.004616367252050254),
+                     (6.35, 0.0036669108501600576),
+                     (6.45, 0.002912730822498961),
+                     (6.55, 0.0023136643324626104),
+                     (6.65, 0.0018378089049495543),
+                     (6.75, 0.0014598235032291457),
+                     (6.85, 0.001159579026329024),
+                     (6.95, 0.0009210863610072359)]
 
         seis_rate_ = 6.0
 

--- a/openquake/mbt/tools/fault_modeler/fault_source_modeler.py
+++ b/openquake/mbt/tools/fault_modeler/fault_source_modeler.py
@@ -194,7 +194,9 @@ def build_model_from_db(fault_db,
                                               width_method=width_method,
                                               param_map=param_map_local,
                                               defaults=defaults_local)
+            print("sfs_dict = ", sfs_dict)
             sfs = fmu.make_fault_source(sfs_dict, oqt_source=oqt_source)
+            print("sfs en build_model_from_db = ", sfs)
             srcl.append(sfs)
 
         except Exception as e:


### PR DESCRIPTION
This PR is to add "m_max" as an attribute of a fault source in the MBTK.
Now, "m_max" is used in a correct manner in "mfd_double_truncated_from_slip_rate_SRC.ipynb".
If "m_max" is passed as an attribute of the source, it is used, otherwise is computed using the fault geometry (area + scaling relation).
A test was added to test_fault_modeling_utils.py 