### PR TITLE
Adding magnitude cut parameter for smoothing

### DIFF
--- a/openquake/mbt/notebooks/nrml/write_nrml_area.ipynb
+++ b/openquake/mbt/notebooks/nrml/write_nrml_area.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -38,21 +38,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "AttributeError",
-     "evalue": "'OQtModel' object has no attribute 'nrml_sources'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-3-500e16280135>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Create the source list\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0msources\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 3\u001b[0;31m \u001b[0;32mfor\u001b[0m \u001b[0mkey\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mmodel\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mnrml_sources\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      4\u001b[0m     \u001b[0msrc\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mmodel\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mnrml_sources\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0msrc\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mAreaSource\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mAttributeError\u001b[0m: 'OQtModel' object has no attribute 'nrml_sources'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#\n",
     "# Create the source list\n",

--- a/openquake/mbt/notebooks/sources_distributed_s/create_sources.ipynb
+++ b/openquake/mbt/notebooks/sources_distributed_s/create_sources.ipynb
@@ -1,6 +1,15 @@
 {
  "cells": [
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# do not remove"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -8,32 +17,6 @@
     "\n",
     "Notes:\n",
     "* The catalogue used for the smoothing contains only earthquakes with magnitude larger than the 'cutoff_magnitude' parameter defined in the .ini file of the project"
-   ]
-  },
-  {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "%%html\n",
-    "<script>\n",
-    "    var code_show=true; //true -> hide code at first\n",
-    "\n",
-    "    function code_toggle() {\n",
-    "        $('div.prompt').hide(); // always hide prompt\n",
-    "\n",
-    "        if (code_show){\n",
-    "            $('div.input').hide();\n",
-    "        } else {\n",
-    "            $('div.input').show();\n",
-    "        }\n",
-    "        code_show = !code_show\n",
-    "    }\n",
-    "    $( document ).ready(code_toggle);\n",
-    "</script>\n",
-    "<p style=\"font-size:60%;\">\n",
-    "<a href=\"javascript:code_toggle()\">[Toggle Code]</a>\n",
-    "<a target=\"_blank\" href=\"./../project/project_set_params_gui.ipynb#\">[Set params]</a>\n",
-    "</p>"
    ]
   },
   {
@@ -249,11 +232,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Then we create the subcatalogue for the dilated polygon\n",
-    "cutoff_magnitude = float(model.catalogue_cutoff_magnitude)\n",
+    "# Set the minimum magnitude used for smoothing\n",
+    "if 'smoothing_minimum_magnitude' in list(model.keys()):\n",
+    "    cutoff_magnitude = float(model.smoothing_minimum_magnitude)\n",
+    "else:\n",
+    "    cutoff_magnitude = float(model.catalogue_cutoff_magnitude)\n",
+    "# Create the subcatalogue for the dilated polygon\n",
     "fcatal = create_catalogue(model, catalogue, polygon=new_polygon)\n",
     "selector = CatalogueSelector(catalogue, create_copy=False)\n",
-    "selector.within_magnitude_range(cutoff_magnitude, 10.)"
+    "selector.within_magnitude_range(cutoff_magnitude, 10.)\n",
+    "fmt = 'Selecting earthquakes above magnitude: {:.2f} (see catalogue_cutoff_magnitude parameter)'\n",
+    "print(fmt.format(model.catalogue_cutoff_magnitude))"
    ]
   },
   {
@@ -608,9 +597,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.4"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/openquake/mbt/notebooks/sources_distributed_s/create_sources.ipynb
+++ b/openquake/mbt/notebooks/sources_distributed_s/create_sources.ipynb
@@ -233,7 +233,7 @@
    "outputs": [],
    "source": [
     "# Set the minimum magnitude used for smoothing\n",
-    "if 'smoothing_minimum_magnitude' in list(model.keys()):\n",
+    "if hasattr(model, 'smoothing_minimum_magnitude'):\n",
     "    cutoff_magnitude = float(model.smoothing_minimum_magnitude)\n",
     "else:\n",
     "    cutoff_magnitude = float(model.catalogue_cutoff_magnitude)\n",
@@ -278,7 +278,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "values = smooth.gaussian(50, 20)\n",
     "values = smooth.multiple_smoothing(smooth_param)\n",
     "print('Max of smoothing:', max(values))"
    ]

--- a/openquake/mbt/notebooks/sources_distributed_s/create_sources_no_faults.ipynb
+++ b/openquake/mbt/notebooks/sources_distributed_s/create_sources_no_faults.ipynb
@@ -209,9 +209,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#\n",
-    "# create the subcatalogue for the dilated polygon\n",
-    "cutoff_magnitude = float(model.catalogue_cutoff_magnitude)\n",
+    "# Set the minimum magnitude used for smoothing\n",
+    "if 'smoothing_minimum_magnitude' in list(model.keys()):\n",
+    "    cutoff_magnitude = float(model.smoothing_minimum_magnitude)\n",
+    "else:\n",
+    "    cutoff_magnitude = float(model.catalogue_cutoff_magnitude)\n",
+    "# Create the subcatalogue for the dilated polygon\n",
     "fcatal = create_catalogue(model, catalogue, polygon=new_polygon)\n",
     "selector = CatalogueSelector(catalogue, create_copy=False)\n",
     "tmp = selector.within_magnitude_range(cutoff_magnitude, 10.)"
@@ -466,7 +469,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.6.9"
   },
   "toc": {
    "nav_menu": {},
@@ -509,5 +512,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/openquake/mbt/notebooks/sources_distributed_s/create_sources_no_faults.ipynb
+++ b/openquake/mbt/notebooks/sources_distributed_s/create_sources_no_faults.ipynb
@@ -210,7 +210,7 @@
    "outputs": [],
    "source": [
     "# Set the minimum magnitude used for smoothing\n",
-    "if 'smoothing_minimum_magnitude' in list(model.keys()):\n",
+    "if hasattr(model, 'smoothing_minimum_magnitude'):\n",
     "    cutoff_magnitude = float(model.smoothing_minimum_magnitude)\n",
     "else:\n",
     "    cutoff_magnitude = float(model.catalogue_cutoff_magnitude)\n",


### PR DESCRIPTION
This PR uses a new parameter assigned to a model called `smoothing_minimum_magnitude` to create an earthquake catalogue specifically used to smooth the seismicity within an area source.