### PR TITLE
GHM csv header

### DIFF
--- a/openquake/ghm/create_map_from_curves.py
+++ b/openquake/ghm/create_map_from_curves.py
@@ -68,7 +68,7 @@ def write_hazard_map(filename, lons, lats, pex, gms, imt):
     print('Created:\n{:s}'.format(filename))
 
 
-def create_map(path_in, prefix, fname_out, path_out, iml_str, pex=None,
+def create_map(path_in, prefix, fname_out, path_out, imt_str, pex=None,
                iml=None):
     """
     :param fname:
@@ -90,7 +90,7 @@ def create_map(path_in, prefix, fname_out, path_out, iml_str, pex=None,
         raise ValueError('You cannot set both iml and pex')
     # Save the hazard map
     path_out = os.path.join(path_out, fname_out)
-    write_hazard_map(path_out, lons, lats, pex, dat, iml_str)
+    write_hazard_map(path_out, lons, lats, pex, dat, imt_str)
 
 
 def main(argv):
@@ -104,7 +104,7 @@ def main(argv):
     p.arg(name='prefix', help='Prefix for selecting files')
     p.arg(name='fname_out', help='Name output csv file')
     p.arg(name='path_out', help='Path to the output folder')
-    p.arg(name='iml_str', help='String describing the IML')
+    p.arg(name='imt_str', help='String describing the IMT')
     p.opt(name='pex', help='Probability of exceedance')
     msg = 'Intensity measure level used for building the maps'
     p.opt(name='iml', help=msg)

--- a/openquake/ghm/create_map_from_curves.py
+++ b/openquake/ghm/create_map_from_curves.py
@@ -61,7 +61,7 @@ def read_hazard_curve_files(path_in, prefix=''):
 def write_hazard_map(filename, lons, lats, pex, gms, imt):
     fou = open(filename, 'w')
     fou.write('# mean, investigation_time=1.0\n')
-    fou.write('lon,lat,PGA-{:f}\n'.format(pex))
+    fou.write('lon,lat,{:s}-{:f}\n'.format(imt, pex))
     for lo, la, gm in zip(lons, lats, gms):
         fou.write('{:f},{:f},{:e}\n'.format(lo, la, gm))
     fou.close()
@@ -90,7 +90,7 @@ def create_map(path_in, prefix, fname_out, path_out, iml_str, pex=None,
         raise ValueError('You cannot set both iml and pex')
     # Save the hazard map
     path_out = os.path.join(path_out, fname_out)
-    write_hazard_map(path_out, lons, lats, pex, dat, 'PGA')
+    write_hazard_map(path_out, lons, lats, pex, dat, iml_str)
 
 
 def main(argv):


### PR DESCRIPTION
Fix the headers of global maps to reflect the correct IMT when they are created. Previously, all maps headers were 'PGA' 