### PR TITLE
adding requirements for py37 for linux

### DIFF
--- a/requirements-py37-linux64.txt
+++ b/requirements-py37-linux64.txt
@@ -1,0 +1,7 @@
+# Suggested versions for development 
+# !! must update pip first! so wheels will be used !!
+
+# GEM Mirror
+https://wheelhouse.openquake.org/v3/linux/py37/pyproj-2.1.3-cp37-cp37m-manylinux1_x86_64.whl
+https://wheelhouse.openquake.org/v3/linux/py37/basemap-1.2.0-cp37-cp37m-manylinux1_x86_64.whl
+https://wheelhouse.openquake.org/v3/linux/py37/GDAL-2.4.1.post1-cp37-cp37m-manylinux1_x86_64.whl


### PR DESCRIPTION
Adds a requirements<...>.txt file for installing py37 modules on linux using wheels. Note that we miss a wheel for Rtree for both this and macOS py37 