### PR TITLE
Updated installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,5 @@ cd oq-mbtk
 
 ### how to run tests:
 ```
-nosetests -vsx -a '!slow'
-```
-
-### how to run tests with coverage:
-```
-nosetests -vsx -a '!slow'  --with-coverage --cover-package=openquake.mbt openquake/mbt --cover-package=openquake.man openquake/man --cover-package=openquake.sub ../oq-subduction/openquake/sub
+pytest -vsx openquake
 ```

--- a/requirements-py36-linux64.txt
+++ b/requirements-py36-linux64.txt
@@ -1,9 +1,0 @@
-# Suggested versions for development based on
-# Ubuntu 18.04 stack
-# !! must update pip first! so wheels will be used !!
-
-# GEM Mirror
-https://wheelhouse.openquake.org/v2/linux/py36/pyproj-1.9.5.1-cp36-cp36m-manylinux1_x86_64.whl
-https://wheelhouse.openquake.org/v2/linux/py36/basemap-1.1.0-cp36-cp36m-manylinux1_x86_64.whl
-https://wheelhouse.openquake.org/v2/linux/py36/GDAL-2.4.1-cp36-cp36m-manylinux1_x86_64.whl
-https://wheelhouse.openquake.org/v2/linux/py36/Rtree-0.8.3-cp36-cp36m-manylinux1_x86_64.whl

--- a/requirements-py36-macos.txt
+++ b/requirements-py36-macos.txt
@@ -1,9 +1,0 @@
-# Suggested versions for development based on
-# Ubuntu 18.04 stack
-# !! must update pip first! so wheels will be used !!
-
-# GEM Mirror
-https://wheelhouse.openquake.org/v2/macos/py36/pyproj-1.9.5.1-cp36-cp36m-macosx_10_6_intel.whl
-https://wheelhouse.openquake.org/v2/macos/py36/basemap-1.1.0-cp36-cp36m-macosx_10_6_intel.whl
-https://wheelhouse.openquake.org/v2/macos/py36/GDAL-2.4.1-cp36-cp36m-macosx_10_9_x86_64.whl
-https://wheelhouse.openquake.org/v2/macos/py36/Rtree-0.8.3-cp36-cp36m-macosx_10_6_intel.whl

--- a/requirements-py36-win64.txt
+++ b/requirements-py36-win64.txt
@@ -1,9 +1,0 @@
-# Suggested versions for development based on
-# Ubuntu 18.04 stack
-# !! must update pip first! so wheels will be used !!
-
-# GEM Mirror
-https://wheelhouse.openquake.org/v2/windows/py36/pyproj-1.9.5.1-cp36-cp36m-win_amd64.whl
-https://wheelhouse.openquake.org/v2/windows/py36/basemap-1.1.0-cp36-cp36m-win_amd64.whl
-https://wheelhouse.openquake.org/v2/windows/py36/GDAL-2.4.1-cp36-cp36m-win_amd64.whl
-https://wheelhouse.openquake.org/v2/windows/py36/Rtree-0.8.3-cp36-cp36m-win_amd64.whl

--- a/requirements-py37-macos.txt
+++ b/requirements-py37-macos.txt
@@ -1,7 +1,0 @@
-# Suggested versions for development 
-# !! must update pip first! so wheels will be used !!
-
-# GEM Mirror
-https://wheelhouse.openquake.org/v3/macos/py37/pyproj-2.1.3-cp37-cp37m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
-https://wheelhouse.openquake.org/v3/macos/py37/basemap-1.2.0-cp37-cp37m-macosx_10_9_x86_64.whl
-https://wheelhouse.openquake.org/v3/macos/py37/GDAL-2.4.1-cp37-cp37m-macosx_10_9_x86_64.whl


### PR DESCRIPTION
Since now we moved to Python 3.8 and GDAL is included in the engine we do not need requirements.txt