### PR TITLE
Fix converter

### DIFF
--- a/openquake/cat/isc_homogenisor.py
+++ b/openquake/cat/isc_homogenisor.py
@@ -36,7 +36,7 @@ from __future__ import print_function
 import numpy as np
 from scipy.misc import derivative
 from datetime import date
-from math import exp, sqrt
+from math import sqrt
 from openquake.cat.utils import _prepare_coords
 
 
@@ -57,7 +57,7 @@ def ISCMs_toGCMTMw(magnitude):
     Converts an ISC-Ms value to Mw using the ISC-GEM exponential regression
     model
     '''
-    return [exp(-0.22 + (0.23 * m)) + 2.86 for m in np.array(magnitude).flatten()]
+    return np.exp(-0.22 + (0.23 * magnitude)) + 2.86
 
 
 def ISCMs_toGCMTMw_Sigma(magnitude):
@@ -71,7 +71,7 @@ def ISCmb_toGCMTMw(magnitude):
     Converts an ISC-mb value to Mw using the ISC-GEM exponential regression
     model
     '''
-    return [exp(-4.66 + (0.86 * m)) + 4.56 for m in np.array(magnitude).flatten()]
+    return np.exp(-4.66 + (0.86 * magnitude)) + 4.56
 
 
 def ISCmb_toGCMTMw_Sigma(magnitude):
@@ -100,7 +100,7 @@ def ISCGORmb_toGCMTMw(magnitude):
     Converts an ISC-mb value to Mw using the ISC-GEM general orthogonal
     regression model
     '''
-    return [1.38 * m - 1.79 for m in np.array(magnitude).flatten()]
+    return 1.38 * magnitude - 1.79
 
 
 def ISCGORmb_toGCMTMw_Sigma(magnitude):

--- a/openquake/cat/isc_homogenisor.py
+++ b/openquake/cat/isc_homogenisor.py
@@ -57,7 +57,7 @@ def ISCMs_toGCMTMw(magnitude):
     Converts an ISC-Ms value to Mw using the ISC-GEM exponential regression
     model
     '''
-    return [exp(-0.22 + (0.23 * m)) + 2.86 for m in magnitude]
+    return [exp(-0.22 + (0.23 * m)) + 2.86 for m in np.array(magnitude).flatten()]
 
 
 def ISCMs_toGCMTMw_Sigma(magnitude):
@@ -71,7 +71,7 @@ def ISCmb_toGCMTMw(magnitude):
     Converts an ISC-mb value to Mw using the ISC-GEM exponential regression
     model
     '''
-    return [exp(-4.66 + (0.86 * m)) + 4.56 for m in magnitude]
+    return [exp(-4.66 + (0.86 * m)) + 4.56 for m in np.array(magnitude).flatten()]
 
 
 def ISCmb_toGCMTMw_Sigma(magnitude):
@@ -86,7 +86,7 @@ def ISCGORMs_toGCMTMw(magnitude):
     regression model
     '''
     return [0.67 * m + 2.13 if m <= 6.47 else 1.10 * m - 0.67 
-            for m in magnitude]
+            for m in np.array(magnitude).flatten()]
 
 
 def ISCGORMs_toGCMTMw_Sigma(magnitude):
@@ -100,7 +100,7 @@ def ISCGORmb_toGCMTMw(magnitude):
     Converts an ISC-mb value to Mw using the ISC-GEM general orthogonal
     regression model
     '''
-    return [1.38 * m - 1.79 for m in magnitude]
+    return [1.38 * m - 1.79 for m in np.array(magnitude).flatten()]
 
 
 def ISCGORmb_toGCMTMw_Sigma(magnitude):

--- a/openquake/cat/isc_homogenisor.py
+++ b/openquake/cat/isc_homogenisor.py
@@ -57,7 +57,7 @@ def ISCMs_toGCMTMw(magnitude):
     Converts an ISC-Ms value to Mw using the ISC-GEM exponential regression
     model
     '''
-    return exp(-0.22 + (0.23 * magnitude)) + 2.86
+    return [exp(-0.22 + (0.23 * m)) + 2.86 for m in magnitude]
 
 
 def ISCMs_toGCMTMw_Sigma(magnitude):
@@ -71,7 +71,7 @@ def ISCmb_toGCMTMw(magnitude):
     Converts an ISC-mb value to Mw using the ISC-GEM exponential regression
     model
     '''
-    return exp(-4.66 + (0.86 * magnitude)) + 4.56
+    return [exp(-4.66 + (0.86 * m)) + 4.56 for m in magnitude]
 
 
 def ISCmb_toGCMTMw_Sigma(magnitude):
@@ -85,10 +85,8 @@ def ISCGORMs_toGCMTMw(magnitude):
     Converts an ISC-Ms value to Mw using the ISC-GEM general orthogonal
     regression model
     '''
-    if magnitude <= 6.47:
-        return 0.67 * magnitude + 2.13
-    else:
-        return 1.10 * magnitude - 0.67
+    return [0.67 * m + 2.13 if m <= 6.47 else 1.10 * m - 0.67 
+            for m in magnitude]
 
 
 def ISCGORMs_toGCMTMw_Sigma(magnitude):
@@ -102,7 +100,7 @@ def ISCGORmb_toGCMTMw(magnitude):
     Converts an ISC-mb value to Mw using the ISC-GEM general orthogonal
     regression model
     '''
-    return 1.38 * magnitude - 1.79
+    return [1.38 * m - 1.79 for m in magnitude]
 
 
 def ISCGORmb_toGCMTMw_Sigma(magnitude):


### PR DESCRIPTION
Modifies magnitude conversion rules to work correctly with magnitude arrays as occurs [here](https://github.com/GEMScienceTools/oq-mbtk/blob/2a1cdc55d85cc7ef2e8891cf85929d63767d7da6/openquake/cat/catalogue_query_tools.py#L1106) in addition to for single values.

