### PR TITLE
Fm scalar fix and test 

### DIFF
--- a/openquake/mbt/tests/tools/fault_modeler/test_fault_modeling_utils.py
+++ b/openquake/mbt/tests/tools/fault_modeler/test_fault_modeling_utils.py
@@ -239,9 +239,19 @@ class TestModelingUtils(unittest.TestCase):
     def test_net_slip_from_strike_slip_shortening(self):
         pass
 
-    @unittest.skip("not yet implemented")
+    #@unittest.skip("not yet implemented")
     def test_net_slip_from_vert_slip_shortening(self):
-        pass
+        fault = {'coords': [[0., 0.], [0., 1.]],
+                'shortening_rate': '(2.,1.,3.)', 
+                'vert_slip_rate': '(2.,1.,3.)', 
+                'slip_type': 'Reverse-Dextral'}
+
+        net_slip_rate = fmu.net_slip_from_vert_slip_shortening(fault)
+
+        net_slip_true_rate = 3.999999999934677
+
+        self.assertTrue(abs(net_slip_rate - net_slip_true_rate) < 0.01)
+                 
 
     @unittest.skip("not yet implemented")
     def test_net_slip_from_vert_strike_slip(self):

--- a/openquake/mbt/tools/fault_modeler/fault_modeling_utils.py
+++ b/openquake/mbt/tools/fault_modeler/fault_modeling_utils.py
@@ -1323,8 +1323,8 @@ def dip_slip_from_vert_slip(fault_dict, slip_class='mle', _abs=True,
                                      slip_class=slip_class,
                                      param_map=param_map)
 
-    dips = get_vals_from_tuple(fetch_param_val(fault_dict, 'average_dip',
-                                               param_map=param_map))
+    dips = get_dip(fault_dict, requested_val='all', defaults=defaults,
+                    param_map=param_map)
 
     dip_slip_rate = vert_slip_rate / np.sin(np.radians(dips))
 
@@ -1575,6 +1575,8 @@ def net_slip_from_vert_slip_shortening(fault_dict, slip_class='mle', _abs=True,
 
     net_slip_rates = dip_slip_rate / np.cos(rake_diffs)
 
+    if np.isscalar(net_slip_rates):
+        return net_slip_rates
     if slip_class == 'mle':
         if len(net_slip_rates) == 3:
             return net_slip_rates[0]

--- a/openquake/mbt/tools/fault_modeler/fault_modeling_utils.py
+++ b/openquake/mbt/tools/fault_modeler/fault_modeling_utils.py
@@ -501,6 +501,7 @@ def get_vals_from_tuple(tup):
     if len(vals) == 0:
         raise Exception(ValueError)
     elif len(vals) == 1:
+        print(vals)
         return vals
     elif len(vals) > 3:
         raise ValueError
@@ -1023,7 +1024,6 @@ def get_rake(fault_dict, requested_val='mle', defaults=defaults,
             rake = rake_map[slip_type]
         except KeyError as e:
             print(e)
-
     return rake
 
 
@@ -1273,10 +1273,13 @@ def net_slip_from_strike_slip_fault_geom(fault_dict, slip_class='mle',
     if _abs is True:
         net_slip_rate = np.abs(net_slip_rate)
 
-    if np.isscalar(rake):
+    if np.isscalar(net_slip_rate):
         return net_slip_rate
     elif slip_class == 'mle':
-        return np.sort(net_slip_rate)[1]
+        if len(net_slip_rate) == 3:
+            return np.sort(net_slip_rate)[0]
+        elif len(net_slip_rate) == 1:
+            return net_slip_rate[0]
     elif slip_class == 'min':
         return np.min(net_slip_rate)
     elif slip_class == 'max':
@@ -1718,8 +1721,9 @@ def dip_slip_from_shortening(fault_dict, slip_class='mle', _abs=True,
     short_rate = fetch_slip_rate(fault_dict, 'shortening_rate',
                                  slip_class=slip_class,
                                  param_map=param_map)
-    dips = get_vals_from_tuple(fetch_param_val(fault_dict, 'average_dip',
-                                               param_map=param_map))
+    dips = get_dip(fault_dict, defaults=defaults, param_map=param_map)
+#    dips = get_vals_from_tuple(fetch_param_val(fault_dict, 'average_dip',
+#                                               param_map=param_map))
     if np.isscalar(dips):
         dip = dips
     elif len(dips) == 1:
@@ -2056,7 +2060,7 @@ def calc_fault_width_from_length(
 
 WIDTH_CLASS = {'cl1': ['Normal', 'Reverse', 'Thrust', 'Normal-Dextral',
                        'Normal-Sinistral', 'Reverse-Sinistral',
-                       'Reverse-Dextral', 'Spreading-Ridge',
+                       'Reverse-Dextral', 'Spreading_Ridge',
                        'Blind-Thrust'],
                'cl2': ['Dextral', 'Sinistral', 'Strike-Slip',
                        'Dextral-Normal', 'Dextral-Reverse',

--- a/openquake/mbt/tools/fault_modeler/fault_modeling_utils.py
+++ b/openquake/mbt/tools/fault_modeler/fault_modeling_utils.py
@@ -1722,8 +1722,7 @@ def dip_slip_from_shortening(fault_dict, slip_class='mle', _abs=True,
                                  slip_class=slip_class,
                                  param_map=param_map)
     dips = get_dip(fault_dict, defaults=defaults, param_map=param_map)
-#    dips = get_vals_from_tuple(fetch_param_val(fault_dict, 'average_dip',
-#                                               param_map=param_map))
+
     if np.isscalar(dips):
         dip = dips
     elif len(dips) == 1:

--- a/openquake/mbt/tools/fault_modeler/fault_modeling_utils.py
+++ b/openquake/mbt/tools/fault_modeler/fault_modeling_utils.py
@@ -501,7 +501,6 @@ def get_vals_from_tuple(tup):
     if len(vals) == 0:
         raise Exception(ValueError)
     elif len(vals) == 1:
-        print(vals)
         return vals
     elif len(vals) > 3:
         raise ValueError

--- a/openquake/mbt/tools/fault_modeler/fault_modeling_utils.py
+++ b/openquake/mbt/tools/fault_modeler/fault_modeling_utils.py
@@ -685,7 +685,7 @@ rake_map = {'Normal': -90.,
             'Strike-Slip': 0.,
             'Thrust': 90.,
             'Blind-Thrust': 90.,
-            'Spreading-Ridge': -90.}
+            'Spreading_Ridge': -90.}
 
 dip_map = {'Normal': 60.,
            'Normal-Dextral': 65.,
@@ -702,7 +702,7 @@ dip_map = {'Normal': 60.,
            'Strike-Slip': 90.,
            'Thrust': 40.,
            'Blind-Thrust': 40.,
-           'Spreading-Ridge': 60.}
+           'Spreading_Ridge': 60.}
 
 # To transform literal values into numbers
 direction_map = {'N': 0.,


### PR DESCRIPTION
- replaces  get_values_from_tuple() with get_dip() in one position 
- adds option for net_slip_rates as scalar instead of array in net_slip_from_vert_slip_shortening()
- adds test for net_slip_from_vert_slip_shortening()