### PR TITLE
minor fix to create_homogenised_curves.py

### DIFF
--- a/openquake/ghm/create_homogenised_curves.py
+++ b/openquake/ghm/create_homogenised_curves.py
@@ -262,7 +262,7 @@ def process_maps(contacts_shp, outpath, datafolder, sidx_fname, boundaries_shp,
             np.testing.assert_allclose(imts_save, imts, rtol=1e-5)
         # Fixing an issue at the border between waf and ssa
         # TODO can we remove this now?
-        if key in ['waf18', 'ssa18']:
+        if key in ['waf', 'ssa']:
             from shapely.geometry import Polygon
             coo = get_poly_from_str(mosaic.SUBSETS[key]['AO'][0])
             df = pd.DataFrame({'name': ['tmp'], 'geo': [Polygon(coo)]})


### PR DESCRIPTION
Since the year mentioned in the models as a suffix has been removed from the shapefiles and mosaic.py, It was necessary to remove the same from L264 of create_homogenised_curves.py.