### PR TITLE
Adaptive smoothing

### DIFF
--- a/bin/wkf_adaptive_smoothing.py
+++ b/bin/wkf_adaptive_smoothing.py
@@ -1,0 +1,95 @@
+#! /usr/bin/env python
+
+import openquake.mbt.tools.adaptive_smoothing as ak
+from openquake.hmtk.parsers.catalogue import CsvCatalogueParser
+
+import numpy as np
+import pandas as pd
+import geopandas as gpd
+import toml
+import h3
+from shapely.geometry import Point
+from openquake.baselib import sap
+from openquake.hazardlib.geo.geodetic import geodetic_distance, distance, _prepare_coords 
+
+def main(catalogue, h3_map, config, outputfile, plot = False):
+        '''
+        Runs an analysis of adaptive smoothed seismicity of Helmstetter et al (2007).
+
+        :param catalogue:
+            An earthquake catalogue csv file containing the following columns -
+            'longitude' - numpy.ndarray vector of longitudes
+            'latitude' - numpy.ndarray vector of latitudes
+
+
+        :param dict config:
+            Location of toml file with model configuration. The following settings are necessary:
+            * 'kernel' - Kernel choice for adaptive smoothing. Options are "Gaussian" or "PowerLaw" (string)
+            * 'n_v' - number of nearest neighbour to use for smoothing distance (int). Use the Information Gain to calibrate this.
+            * 'd_i_min' - minimum smoothing distance d_i, should be chosen based on location uncertainty. Default of 0.5 in Helmstetter et al. (float)
+        
+        :param output_file:
+            String specifying location in which to save output.
+            
+        :param plot:
+            Option to plot result to see smoothing
+
+        :returns:
+            Full smoothed seismicity data as np.ndarray, of the form
+            [Longitude, Latitude, Smoothed], a plot if required.
+        '''
+	    
+        # Read h3 indices from mapping file
+        h3_idx = pd.read_csv(h3_map)
+        
+                
+        # Get lat/lon locations for each h3 cell, convert to seperate lat and lon columns of dataframe
+        h3_idx['latlon'] = h3_idx.iloc[:,0].apply(h3.h3_to_geo)
+        locations = pd.DataFrame(h3_idx['latlon'].tolist())  
+        locations.columns = ["lat", "lon"]
+        
+        # Load config file to get smoothing parameters
+        config = toml.load(config)
+        
+        # Load catalogue csv. Uses CsvCatalogueParser for compatability with hmtk catalogue outputs. Should work with any csv so long as 'longitude' and 'latitude' cols are present
+        cat = catalogue
+        parser = CsvCatalogueParser(cat)
+        cat = parser.read_file()
+        cat.sort_catalogue_chronologically()
+        
+	# Run adaptive smoothing over chosen area, don't grid the data (h3 locs, already done!), don't use depths.
+        smooth = ak.AdaptiveSmoothing([locations.lon, locations.lat], grid = False, use_3d = False)
+        conf = {"kernel": config["kernel"], "n_v": config['n_v'], "d_i_min": config['d_i_min']}
+        out = smooth.run_adaptive_smooth(cat, conf )
+        # Make output into dataframe with named columns and write to a csv file in specified loctaion
+        out = pd.DataFrame(out)
+        out.columns = ["lon", "lat", "nocc"]
+        
+        out["nocc"] = out["nocc"]
+        out.to_csv(outputfile, header = True)
+        
+        if (plot == True):
+            plot_adaptive_smoothing(outputfile)
+        
+
+def plot_adaptive_smoothing(smoothingfile):
+    out = pd.read_csv(smoothingfile)
+    plt.scatter(out["lon"], out["lat"], c=out["nocc"], cmap="viridis")
+    plt.colorbar(label="event density")
+    plt.scatter(mor_cat.data['longitude'], mor_cat.data['latitude'], s = 0.5, c="k")
+    plt.xlabel("longitude")
+    plt.ylabel("latitude")
+    plt.show()
+    
+
+descr = 'Instance of the openquake.hmtk.seismicity.catalogue.Catalogue class'
+main.catalogue = descr
+descr = 'h3 cells in which to calculate rate'
+main.h3_locations = descr
+descr = 'Config file defining the parameters for smoothing'
+main.config = descr
+descr = 'Name of file to save output to'
+main.outputfile = descr
+
+if __name__ == '__main__':
+    sap.run(main)

--- a/openquake/mbt/tools/adaptive_smoothing.py
+++ b/openquake/mbt/tools/adaptive_smoothing.py
@@ -1,0 +1,277 @@
+'''
+Module :mod:`openquake.mbt.tools.adaptive_smoothing`
+
+Implements the spatial adaptive smoothing method of Helmstetter et al (2007) 
+
+'''
+import numpy as np
+import pandas as pd
+import geopandas as gpd
+import scipy as sp
+import matplotlib.pyplot as plt
+from shapely.geometry import Point
+from openquake.baselib import sap
+from openquake.hazardlib.geo.geodetic import geodetic_distance, distance, _prepare_coords 
+
+
+class AdaptiveSmoothing(object):
+    '''
+    Applies Helmstetter (2007) adaptive smoothing kernel to the data
+    
+    
+    '''
+    
+    def __init__(self, locations, grid=False, use_3d=False, bvalue=None):
+        '''
+        Instantiate class with locations at which to calculate intensity
+
+        :param locations:
+            Expects a list of longitude and latitude locations. Set grid = True to constrcut meshgrid from x, y locations.
+
+        :param bool use_3d:
+            Choose whether to use hypocentral distances for smoothing or only
+            epicentral
+
+        :param float bval:
+            b-value for analysis
+        '''
+        self.locations = locations
+        self.catalogue = None
+        self.grid = grid
+        self.use_3d = use_3d
+        self.bval = bvalue
+        if self.bval:
+            self.beta = self.bval * log(10.)
+        else:
+            self.beta = None
+        self.data = None
+
+        self.kernel = None
+
+    
+    def run_adaptive_smooth(self, catalogue, config):
+        '''
+        Runs an analysis of adaptive smoothed seismicity of Helmstetter et al (2007).
+
+        :param catalogue:
+            Instance of the openquake.hmtk.seismicity.catalogue.Catalogue class
+            catalogue.data dictionary containing the following -
+            'year' - numpy.ndarray vector of years
+            'longitude' - numpy.ndarray vector of longitudes
+            'latitude' - numpy.ndarray vector of latitudes
+            'depth' - numpy.ndarray vector of depths
+            (can use CsvParser to adapt any csv file to Catalogue for this step)
+
+        :param dict config:
+            Configuration settings of the algorithm:
+            * 'kernel' - Kernel choice for adaptive smoothing. Options are "Gaussian" or "PowerLaw" (string)
+            * 'n_v' - number of nearest neighbour to use for smoothing distance (int)
+            * 'd_i_min' - minimum smoothing distance d_i, should be chosen based on location uncertainty. Default of 0.5 in Helmstetter et al. (float)
+            
+        :returns:
+            Smoothed seismicity data as np.ndarray, of the form
+            [Longitude, Latitude, Smoothed_value]
+        '''
+
+        
+        data = np.stack((catalogue.data['longitude'], 
+        				 catalogue.data['latitude'],
+        				 catalogue.data['depth'], 
+        				 catalogue.data['magnitude']), axis = 1)
+        self.data = data
+        # To create a grid of data if required:
+        if self.grid == True:
+        	## Convert x, y locs to meshgrid
+        	xx, yy = np.meshgrid(self.locations[0], self.locations[1])
+        	## Flatten to get all x and y coords on grid
+        	x = xx.flatten()
+        	y = yy.flatten()
+        else:
+        	x = self.locations[0]
+        	y = self.locations[1]
+        	
+	# Remember that python indexing starts at 0! Make sure this is the correct value.
+        n_v = (config['n_v']-1)
+        kernel = config['kernel']
+       
+        # Use depths if 3D model required, otherwise all depths set to 0
+        if self.use_3d:
+            depth = data[:,2]
+        else:
+            depth = np.zeros(len(data))
+        
+        d_i = np.empty(len(data))
+        # Get smoothing parameter d for each earthquake
+        for iloc in range(0, len(data)):
+            r = distance(data[:, 0], data[:, 1], depth, data[iloc, 0], data[iloc, 1], depth[iloc])
+            r = np.delete(r, iloc)
+            r.sort()
+            d_i[iloc] = r[n_v]
+
+       # Set minimum d_i
+        
+        d_i[d_i < config['d_i_min']] = config['d_i_min']
+        mu_loc = np.empty(len(x))
+        
+	# Calculate mu at each location 
+        for iloc in range(0, len(x)):
+ 		   # Distance from each event to the location
+            r_dists = distance(data[:, 0], data[:, 1], depth, x[iloc], y[iloc], 0)
+            mu_loc[iloc] = self.mu_int(r_dists, d_i, kernel = kernel)
+
+
+        self.out = pd.DataFrame({'lon': x, 'lat' : y, 'nocc' : mu_loc})
+
+        return self.out
+
+    
+    def Gaussian_K(self, r, d):
+        '''
+        Calculates value of Gaussian smoothing kernel K at a given point location
+        
+        :param d:
+            Smoothing distance: the distance between event i and the nth neighbour, where n is an optimisable parameter   
+        :param r:
+            Distance between event and a point location 
+            
+        :returns:
+            Kernel estimate of smoothed seisimicity at location r
+            
+        '''
+        # Normalising factor C so integral of K = 1
+        C = 1/(np.sqrt(2*np.pi)*d)
+    	# Gaussian smoothing kernel with weight d
+        K = C*np.exp(-(r**2/(2*d**2)))
+        
+        return(K)
+    	
+    def PL_K(self, r, d):
+        '''
+        Calculates value of power law smoothing kernel K at a given point location
+        
+        :param d:
+            Smoothing distance: the distance between event i and the nth neighbour, where n is an optimisable parameter
+        :param r:
+            Distance between event and a point location 
+            
+        :returns:
+            Kernel estimate of smoothed seisimicity at location r
+            
+        '''
+        ## Normalising constant so that integral (-inf, inf) = 1
+        C = (d**2)/2
+        K = C/(r**2 + d**2)**1.5
+        return(K)
+    
+
+    def mu_int(self, r, d, kernel = "Gaussian"):
+        '''
+        Calculates intensity at given locations as sum of all kernel contributions K
+        
+        :param d:
+            Smoothing distance: the distance between event i and the nth neighbour, where n is an optimisable parameter
+        :param r:
+            Distance between event and a point location x
+        :param kernel:
+            Options for choice of smoothing kernel. Accepts "Gaussian" or "PowerLaw" and calls the appropriate kernel
+            
+        :returns:
+            * mu intensity at a point x as a function of all surrounding events with smoothing distance d
+            
+        '''
+        mu_i = np.empty(len(r))
+    
+        for i, distance in enumerate(r):
+            
+            if kernel == "Gaussian":
+                mu_i[i] = self.Gaussian_K(distance, d[i])
+            
+            elif kernel == "PowerLaw":
+                mu_i[i] = self.PL_K(distance, d[i])
+    
+        mu_sum = (np.sum(mu_i))
+        return mu_sum
+
+ 
+    
+    def poiss_loglik(self, rate_lambda, obs, T=1):
+        '''
+        Calculate the poisson likelihood, given the observed number of events and the forecast rate. 
+        
+        :param rate_lambda:
+            expected number of events 
+        :param obs:
+            observed number of events
+        :param T:
+            Scaling of forecast to observations. For example, a forecast built with 100 years of data tested over a ten year testing period should have T = 0.1, or a 1 year forecast tested over 5 years would have T = 5
+            
+        :returns:
+            likelihood value 
+        '''
+        l = -rate_lambda*T - np.log(sp.special.factorial(obs)) + np.log(rate_lambda*T)* obs
+        return l
+
+    def plot_smoothing(self, log_density = False, plot_cat = False):
+        '''
+        Plot adaptive smoothing outputs given a csv file of smoothing values (lon, lat, nocc).
+        Compatible with output of adaptive or fixed kernel smoothing approaches
+        
+        :param smooth_out:
+            Location of output file containing the adaptive smoothing results
+        
+        '''
+        out = self.out
+        if (log_density == True):
+            density = np.log10(out["nocc"])
+            lab = "log10 event density"
+        else:
+            density = out["nocc"]
+            lab = "event density"
+        plt.scatter(out["lon"], out["lat"], c=density, cmap="viridis")
+        plt.colorbar(label= lab)
+        plt.xlabel("longitude")
+        plt.ylabel("latitude")
+        if (plot_cat == True):
+            plt.scatter(self.data[:, 0], self.data[:,1], s = 1, c = "k")
+        plt.show()
+        
+
+    def information_gain(self, counts, T = 1, read_counts_from_file = False, fname_counts = None):
+        '''
+        Calculates the information gain per event given a smoothing model and a list of model counts
+        Counting results should match the cells of the smoothed rates. 
+        
+        :param counts:
+            counts in grid cells matching the smoothed cells stored in self.out
+        :param T:
+            optional time scaling for testing rates over a fixed time period
+        :param read_counts_from_file:
+            if True, read count data from a csv instead of using directly supplied counts
+        :param fname_counts:
+            if read_counts_from_file is True, read counts from specified file.
+             
+        '''
+        
+        # Set counts from a file if provided, or using count array directly
+        if (read_counts_from_file == True):
+            loc_df = pd.read_csv(fname_counts)
+            loc_counts = gpd.GeoDataFrame(loc_df, crs='epsg:4326', geometry=[Point(xy) for xy
+                       in zip(loc_df.lon, loc_df.lat)])
+        else:
+            loc_counts = pd.DataFrame({'lon': self.out['lon'], 'lat' : self.out['lat'], 'nocc' : self.out['nocc']})
+    
+        # Uniform rate = total sum distributed over all hexagons, so uniform count is sum/num hexagons
+        unif_cnt = sum(loc_counts['nocc'])/len(loc_counts)
+        # Calculate poisson likelihood of uniform model
+        unif_llhood = self.poiss_loglik(unif_cnt, loc_counts['nocc'], T)
+    
+        smoothed = self.out
+        smoothed = gpd.GeoDataFrame(smoothed, crs='epsg:4326', geometry=[Point(xy) for xy
+                       in zip(smoothed.lon, smoothed.lat)])
+        # Model likelihood
+        mod_llhood = self.poiss_loglik(smoothed['nocc'], loc_counts['nocc'], T)
+    
+        # Information gain = exp(llhood - unif_llhood)/total_event_num
+        IG = np.exp((sum(mod_llhood)-sum(unif_llhood))/sum(loc_counts['nocc']))
+        return IG
+

--- a/openquake/wkf/wkf_h3_zones_cat.py
+++ b/openquake/wkf/wkf_h3_zones_cat.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import os
+import h3
+import json
+import shapely
+import geopandas as gpd
+import pandas as pd
+from shapely.geometry import Point, Polygon, LineString
+from openquake.baselib import sap
+
+def main(h3_level: str, fname_catalogue : str, fname_out: str):
+    '''
+    Construct H3 zones covering area of extent of catalogue. ToDo: Map cells to source zones. 
+    
+    :param h3_level: 
+        resolution to set h3 cells to
+    :param fname_catalogue:
+        Location of catalogue csv file
+    :param fname_out:
+        Folder in which to save the output.
+    '''
+    
+    h3_level = int(h3_level)
+    
+    df = pd.read_csv(fname_catalogue)
+    catalogue = gpd.GeoDataFrame(df, crs='epsg:4326', geometry=[Point(xy) for xy
+                           in zip(df.longitude, df.latitude)])
+    
+    # Make boundary polygon from catalogue extent                       
+    xmin,ymin,xmax,ymax  = catalogue.total_bounds
+    polygon = shapely.geometry.Polygon([(xmin, ymin),  (xmax, ymin), (xmax, ymax), (xmin, ymax),  (xmin, ymin)])
+
+    gojpol = eval(json.dumps(shapely.geometry.mapping(polygon)))
+    
+    # Revert the positions of lons and lats
+    coo = [[c[1], c[0]] for c in gojpol['coordinates'][0]]
+    gojpol['coordinates'] = [coo]
+    
+    # Generate h3 hexagons over the area, save in dataframe
+    hexagons = list(h3.polyfill(gojpol, h3_level))
+    
+    fout = open(fname_out, 'w')
+    for hxg in hexagons:
+        # TODO: Update this to take correct source zone names from source zone polygons
+        zid = 1
+        fout.write("{:s},{:d}\n".format(hxg, zid))
+
+main.h3_level = "h3 resolution level"
+main.fname_catalogue = "file containing an earthquake catalogue in .csv format"
+main.fname_out = "The name of the output folder where to save .csv files"
+
+
+if __name__ == '__main__':
+    sap.run(main)

--- a/openquake/wkf/wkf_info_gain.py
+++ b/openquake/wkf/wkf_info_gain.py
@@ -1,0 +1,107 @@
+#! /usr/bin/env python
+
+import numpy as np
+import pandas as pd
+import geopandas as gpd
+import scipy as sp
+import h3
+
+from shapely.geometry import Point
+from openquake.baselib import sap
+from openquake.hazardlib.geo.geodetic import geodetic_distance, distance, _prepare_coords 
+
+
+def poiss_loglik(rate_lambda, obs, T):
+    '''
+    Calculates Poisson likelihood for given lambda_rate and observations (obs).
+    
+    :param rate_lambda:
+        Rate of events (lambda)
+    :param obs:
+        Observed number of events
+    :param T:
+        Time over which model rate is constructed/tested. e.g. if the forecast rate is for 1 year and the observed data is for 10, T = 10
+        
+    '''
+    l = -rate_lambda*T - np.log(sp.special.factorial(obs)) + np.log(rate_lambda*T)* obs
+    return l
+
+def information_gain(catalogue, h3_map, h3_level, smooth_out, T = 1, for_zone = False):
+    '''
+    Calculates the information gain from a smoothing model, comparing observed and smoothed rates per h3 cell.
+    The information gain is calculated as exp(llhood - unif_llhood)/total_event_num, where poisson likelihoods are calculated using poiss_loglik function. 
+    The uniform likelihood is determined by dividing the observed number of events uniformly across all h3 cells.
+    Significantly slower than the version in adaptive_smoothing.py!
+    
+    :param catalogue:
+        Location of the catalogue to be used when evaluating the model
+    :param h3_map:
+        Location of file including the h3 cells over which the model has been built
+    :param h3_level:
+        Resolution for h3 mapping (must match that used to create the h3_map)
+    :param smooth_out:
+        Output of smoothing file (from adaptive or fixed smoothing), containing columns named lon, lat, nocc. Lon/Lat locations should correspond to h3_cells
+    :param T: 
+        Time rescaling if neccessary
+    
+    :returns: 
+        information gain for given model relative to uniform poisson model with correct number of events
+    '''
+    colnames = ["h3_cell", "zid"]
+    h3_idx = pd.read_csv(h3_map, names=colnames, header = None)
+    print(len(h3_idx))
+    cat_df = pd.read_csv(catalogue)
+    cat_df = gpd.GeoDataFrame(cat_df, crs='epsg:4326', geometry=[Point(xy) for xy
+                       in zip(cat_df.longitude, cat_df.latitude)])
+    #print(len(cat_df))                   
+    smoothed = pd.read_csv(smooth_out)
+    smoothed = gpd.GeoDataFrame(smoothed, crs='epsg:4326', geometry=[Point(xy) for xy
+                       in zip(smoothed.lon, smoothed.lat)])
+    print(len(smoothed))
+    
+    # Find which cell each event in the catalogue belongs to    
+    h3_cell_c = [0]*len(cat_df)
+    for i in range(0,len(cat_df)):
+        h3_cell_c[i] = h3.geo_to_h3(cat_df['latitude'][i], cat_df['longitude'][i], h3_level)
+        
+    cat_df['h3_cell'] = h3_cell_c
+    
+    ## Find which cell each smoothed value is in
+    h3_cell_sm = [0]*len(smoothed)
+    for i in range(0,len(smoothed)):
+        h3_cell_sm[i] = h3.geo_to_h3(smoothed['lat'][i], smoothed['lon'][i], h3_level)
+    
+    smoothed['h3_cell'] = h3_cell_sm
+    
+    # Only keep cells where smoothed value is in h3_map
+    to_use = smoothed[smoothed['h3_cell'].isin(list(h3_idx.h3_cell))]
+    print("kept cells")
+    print(len(to_use))
+    
+    # count events in each h3 cell
+    event_count = [0]*len(h3_idx)
+    for i in range(0, len(h3_idx)):
+        if cat_df['h3_cell'].str.contains(h3_idx.iloc[i, 0]).any():
+            event_count[i] = cat_df['h3_cell'].value_counts()[h3_idx.iloc[i,0]]
+    
+    h3_idx['count'] = event_count
+    
+    # Combine cell information into one dataframe
+    h3_idx =h3_idx.merge(to_use, how = 'left', on = "h3_cell")
+    
+    # For cells where there is no calculated smoothing, set to a very small value
+    # (0s break the likelihood calculation, but 1E-15 is probably close enough)
+    h3_idx['nocc'] = h3_idx['nocc'].replace(np.nan, 1E-15)
+         
+    # Uniform rate = total sum distributed over all hexagons, so uniform count is sum/num hexagons
+    unif_cnt = sum(h3_idx['count'])/len(h3_idx)
+    # Calculate poisson likelihood of uniform model
+    unif_llhood = poiss_loglik(unif_cnt, h3_idx['count'], T)
+    
+    # Model likelihood
+    mod_llhood = poiss_loglik(h3_idx['nocc'], h3_idx['count'], T)
+    
+    # Information gain = exp(llhood - unif_llhood)/total_event_num
+    IG = np.exp((sum(mod_llhood)-sum(unif_llhood))/sum(h3_idx['count']))
+    return IG
+


### PR DESCRIPTION
Adds Helmstetter adaptive smoothing functions to mbtk. 
* Adds a module for adaptive smoothing of catalogue data, plotting smoothing output and testing the information gain for parameter calibration
* Adds a workflow implementation to fit within the mbt_wkf example. Direct comparison with existing wkf smoothing is provided by wkf_info_gain (though this is currently slower than information gain comparisons in adaptive_smoothing directly).