### PR TITLE
Keep focal mechanism info during merge

### DIFF
--- a/openquake/cat/gcmt_catalogue.py
+++ b/openquake/cat/gcmt_catalogue.py
@@ -585,7 +585,7 @@ class GCMTCatalogue(object):
         header_list = ['eventID', 'Agency', 'year', 'month', 'day', 'hour',
                    'minute', 'second', 'timeError', 'longitude', 'latitude',
                    'SemiMajor90', 'SemiMinor90', 'ErrorStrike', 'depth',
-                   'depthError', 'magnitude', 'sigmaMagnitude']
+                   'depthError', 'magnitude', 'sigmaMagnitude', 'str1', 'dip1', 'rake1', 'str2', 'dip2', 'rake2']
         with open(filename, 'wt') as fid:
             writer = csv.DictWriter(fid, fieldnames=header_list)
             headers = dict((header, header) for header in header_list)
@@ -601,7 +601,13 @@ class GCMTCatalogue(object):
                             'magnitude': tensor.magnitude,
                             'sigmaMagnitude': None,
                             'depth': None,
-                            'depthError': None}
+                            'depthError': None,
+                            'str1': None,
+                            'dip1': None,
+                            'rake1': None,
+                            'str2': None,
+                            'dip2': None,
+                            'rake2': None}
 
                 if centroid_location:
                     # Time and location come from centroid
@@ -618,6 +624,12 @@ class GCMTCatalogue(object):
                     cmt_dict['latitude'] = tensor.centroid.latitude
                     cmt_dict['depth'] = tensor.centroid.depth
                     cmt_dict['depthError'] = tensor.centroid.depth_error
+                    cmt_dict['str1'] = tensor.nodal_planes.nodal_plane_1['strike']
+                    cmt_dict['rake1'] = tensor.nodal_planes.nodal_plane_1['rake']
+                    cmt_dict['dip1'] = tensor.nodal_planes.nodal_plane_1['dip']
+                    cmt_dict['str2'] = tensor.nodal_planes.nodal_plane_2['strike']
+                    cmt_dict['rake2'] = tensor.nodal_planes.nodal_plane_2['rake']
+                    cmt_dict['dip2'] = tensor.nodal_planes.nodal_plane_2['dip']
                 else:
                     # Time and location come from hypocentre
                     cmt_dict['year'] = tensor.hypocentre.date.year

--- a/openquake/cat/hmg/merge.py
+++ b/openquake/cat/hmg/merge.py
@@ -295,7 +295,7 @@ def process_catalogues(settings_fname: str) -> None:
             # Update the spatial index
             print("      Updating index")
             catroot._create_spatial_index()
-
+        
         nev = catroot.get_number_events()
         print(f"   Whole catalogue contains: {nev:d} events")
 

--- a/openquake/cat/hmg/utils.py
+++ b/openquake/cat/hmg/utils.py
@@ -39,8 +39,15 @@ def to_hmtk_catalogue(cdf: pd.DataFrame):
     """
 
     # Select columns
-    cdf = cdf[['eventID', 'Agency', 'year', 'month', 'day', 'longitude',
-               'latitude', 'depth', 'magMw']]
+    # Check if catalogue contains strike/dip/rake and retain if it does
+    if 'str1' in cdf.columns:
+        col_list = ['eventID', 'Agency', 'year', 'month', 'day', 'longitude',
+               'latitude', 'depth', 'magMw', 'str1', 'dip1', 'rake1', 'str2', 'dip2', 'rake2']
+    else:
+        col_list = ['eventID', 'Agency', 'year', 'month', 'day', 'longitude',
+               'latitude', 'depth', 'magMw']
+    
+    cdf = cdf[col_list]
 
     # Rename columns
     cdf = cdf.rename(columns={"magMw": "magnitude"})

--- a/openquake/cat/isf_catalogue.py
+++ b/openquake/cat/isf_catalogue.py
@@ -53,7 +53,9 @@ DATAMAP = [("eventID", "U20"), ("originID", "U20"), ("Agency", "U14"),
            ("longitude", "f4"), ("latitude", "f4"), ("depth", "f4"),
            ("depthSolution", "U1"), ("semimajor90", "f4"),
            ("semiminor90", "f4"), ("error_strike", "f2"),
-           ("depth_error", "f4"), ("prime", "i1")]
+           ("depth_error", "f4"), ("prime", "i1"), ("dip1", "f4"), 
+           ("rake1", "f4"), ("str1", "f4"), ("dip2", "f4"),
+           ("rake2", "f4"), ("str2", "f4")]
 
 MAGDATAMAP = [("eventID", "U20"), ("originID", "U20"), ("magnitudeID", "U40"),
               ("value", "f4"), ("sigma", "f4"), ("magType", "U6"),
@@ -163,7 +165,9 @@ class Magnitude(object):
 
 class Location(object):
     '''
-    Instance of a magnitude location
+    Instance of a magnitude location. Contains spatial information for a given event to be stored in the origins output.
+    Note that order is very important here. 
+    
     :param int origin_id:
         Identifier as origin ID
     :param float longitude:
@@ -184,10 +188,23 @@ class Location(object):
         Strike of the semimajor axis of the error ellipse
     :param float depth_error:
         1 s.d. Error on the depth value (km)
+    :param float str1:
+        strike from 1st nodal plane
+    :param float dip1:
+        dip from 1st nodal plane
+    :param float rake1:
+        rake from 1st nodal plane
+    :param float str2:
+        strike from 2nd nodal plane
+    :param float dip2:
+        dip from 2nd nodal plane
+    :param float rake2:
+        rake from 2nd nodal plane 
     '''
     def __init__(self, origin_id, longitude: float, latitude: float,
                  depth: float, depthSolution=None, semimajor90=None,
-                 semiminor90=None, error_strike=None, depth_error=None):
+                 semiminor90=None, error_strike=None, depth_error=None, 
+                 str1=None, dip1= None, rake1= None,  str2=None, dip2= None, rake2= None):
         """
         """
         self.identifier = origin_id
@@ -201,6 +218,12 @@ class Location(object):
         self.semiminor90 = semiminor90
         self.error_strike = error_strike
         self.depth_error = depth_error
+        self.str1 = str1
+        self.dip1 = dip1
+        self.rake1 = rake1
+        self.str2 = str2
+        self.dip2 = dip2
+        self.rake2 = rake2
 
     def __str__(self):
         """
@@ -275,6 +298,7 @@ class Origin(object):
         self.time_rms = time_rms
         self.date_time_str = "|".join([str(self.date).replace("-", "|"),
                                        str(self.time).replace(":", "|")])
+        
 
     def get_number_magnitudes(self):
         """
@@ -1167,6 +1191,7 @@ class ISFCatalogue(object):
                 else:
                     depth_error = 0.0
 
+
                 if (orig.location.depthSolution == 'None' or
                         orig.location.depthSolution == '' or
                         orig.location.depthSolution is None):
@@ -1176,7 +1201,7 @@ class ISFCatalogue(object):
                 else:
                     print('Location:', orig.location.depthSolution)
                     raise ValueError("Unsupported case")
-
+                
                 if (orig.location.depth == 'None' or
                         orig.location.depth == '' or
                         orig.location.depth is None):
@@ -1195,7 +1220,37 @@ class ISFCatalogue(object):
                     prime = 1
                 else:
                     prime = 0
-
+                    
+                if orig.location.dip1:
+                    dip1 = orig.location.dip1
+                else:    
+                    dip1 = 0
+                    
+                if orig.location.str1:
+                    str1 = orig.location.str1
+                else:    
+                    str1 = 0
+                
+                if orig.location.rake1:
+                    rake1 = orig.location.rake1
+                else:    
+                    rake1 = 0
+                    
+                if orig.location.dip2:
+                    dip2 = orig.location.dip2
+                else:    
+                    dip2 = 0
+                    
+                if orig.location.str2:
+                    str2 = orig.location.str2
+                else:    
+                    str2 = 0
+                
+                if orig.location.rake2:  
+                    rake2 = orig.location.rake2
+                else:    
+                    rake2 = 0
+                
                 origin_data[o_counter] = (eq.id, orig.id, orig.author,
                                           orig.date.year, orig.date.month,
                                           orig.date.day, orig.time.hour,
@@ -1205,7 +1260,8 @@ class ISFCatalogue(object):
                                           depth,
                                           depthSolution,
                                           semimajor90, semiminor90,
-                                          error_strike, depth_error, prime)
+                                          error_strike, depth_error, prime,
+                                          dip1,rake1,str1,dip2, rake2, str2 )
 
                 o_counter += 1
 

--- a/openquake/cat/parsers/generic_catalogue.py
+++ b/openquake/cat/parsers/generic_catalogue.py
@@ -49,7 +49,7 @@ class GeneralCsvCatalogue(object):
                             'SemiMajor90', 'SemiMinor90', 'ErrorStrike',
                             'depth', 'depthError', 'magnitude',
                             'sigmaMagnitude', 'moment', 'mpp', 'mpr', 'mrr',
-                            'mrt', 'mtp', 'mtt']
+                            'mrt', 'mtp', 'mtt', 'dip1', 'str1', 'rake1', 'dip2', 'str2', 'rake2']
 
     INT_ATTRIBUTE_LIST = ['year', 'month', 'day', 'hour', 'minute',
                           'flag', 'scaling']
@@ -86,6 +86,9 @@ class GeneralCsvCatalogue(object):
         """
 
         df = pd.read_csv(filename, delimiter=',')
+        # Replace any whitespace with nan
+        df.replace(r'^\s*$', np.nan, regex=True)
+
 
         # Checking information included in the original
         if 'day' in df.columns:
@@ -98,16 +101,40 @@ class GeneralCsvCatalogue(object):
             df.drop(df[df.minute > 59.599999].index, inplace=True)
         if 'hour' in df.columns:
             df.drop(df[df.hour > 23.99999].index, inplace=True)
-
+            
+        if 'str1' in df.columns:
+            df['str1'] = pd.to_numeric(df['str1'], errors='coerce')
+        
+        if 'dip1' in df.columns:
+            df['dip1'] = pd.to_numeric(df['dip1'], errors='coerce')
+ 
+        if 'rake1' in df.columns:
+            df['rake1'] = pd.to_numeric(df['rake1'], errors='coerce')
+            
+        if 'str2' in df.columns:
+            df['str2'] = pd.to_numeric(df['str2'], errors='coerce')
+            
+        if 'dip2' in df.columns:
+            df['dip2'] = pd.to_numeric(df['dip2'], errors='coerce')
+            
+        if 'rake2' in df.columns:
+            df['rake2'] = pd.to_numeric(df['rake2'], errors='coerce')
+        
+        if 'SemiMinor90' in df.columns:
+            df['SemiMinor90']= pd.to_numeric(df['SemiMinor90'], errors='coerce') 
+        
+        if 'SemiMajor90' in df.columns:
+            df['SemiMajor90']= pd.to_numeric(df['SemiMajor90'], errors='coerce') 
         # Processing columns and updating the catalogue
         for col in df.columns:
             if col in self.TOTAL_ATTRIBUTE_LIST:
                 if (col in self.FLOAT_ATTRIBUTE_LIST or
                         col in self.INT_ATTRIBUTE_LIST):
                     self.data[col] = df[col].to_numpy()
+
                 else:
                     self.data[col] = df[col].to_list()
-
+                    
     def get_number_events(self):
         """
         Returns the number of events
@@ -249,34 +276,59 @@ class GeneralCsvCatalogue(object):
                 error_strike = self.data['ErrorStrike'][iloc]
             else:
                 error_strike = np.nan
-            if len(self.data['ErrorStrike']):
+            if len(self.data['depthError']):
                 depth_error = self.data['depthError'][iloc]
             else:
                 depth_error = np.nan
-            #
-            if np.isnan(semimajor90):
+            if len(self.data['str1']):
+                str1 = self.data['str1'][iloc]
+            else:
+                str1 = np.nan
+            if len(self.data['dip1']):
+                dip1 = self.data['dip1'][iloc]
+            else:
+                dip1 = np.nan
+            if len(self.data['rake1']):
+                rake1 = self.data['rake1'][iloc]
+            else:
+                rake1 = np.nan
+            if len(self.data['str2']):
+                str2 = self.data['str2'][iloc]
+            else:
+                str2 = np.nan
+            if len(self.data['dip2']):
+                dip2 = self.data['dip2'][iloc]
+            else:
+                dip2 = np.nan
+            if len(self.data['rake2']):
+                rake2 = self.data['rake2'][iloc]
+            else:
+                rake2 = np.nan
+
+            if pd.isnull(semimajor90):
                 semimajor90 = None
-            if np.isnan(semiminor90):
+            if pd.isnull(semiminor90):
                 semiminor90 = None
-            if np.isnan(error_strike):
+            if pd.isnull(error_strike):
                 error_strike = None
-            if np.isnan(depth_error):
-                depth_error = None
+            if pd.isnull(depth_error):
+               depth_error = None
 
             # Depth
             if self.data['depth'][iloc] == 'None':
                 tmp_depth = None
             else:
                 tmp_depth = float(self.data['depth'][iloc])
-
+            depthSolution = None
             locn = Location(origin_id,
                             self.data['longitude'][iloc],
                             self.data['latitude'][iloc],
                             tmp_depth,
+                            depthSolution,
                             semimajor90,
                             semiminor90,
                             error_strike,
-                            depth_error)
+                            depth_error, str1, dip1, rake1, str2, dip2, rake2)
 
             # Create Origin
             # Date
@@ -379,11 +431,12 @@ class MixedMagnitudeCsvCatalogue(GeneralCsvCatalogue):
                             self.data['longitude'][iloc],
                             self.data['latitude'][iloc],
                             self.data['depth'][iloc],
+                            depthSolution,
                             semimajor90,
                             semiminor90,
                             error_strike,
                             depth_error)
-
+                                        
             # Create Origin
             # Date
             eq_date = datetime.date(self.data['year'][iloc],

--- a/openquake/cat/tests/isf_catalogue_test.py
+++ b/openquake/cat/tests/isf_catalogue_test.py
@@ -174,7 +174,7 @@ class MergeGenericCatalogueTest(unittest.TestCase):
                 utc_time_zone=timezone, buff_t=dt.timedelta(0), buff_ll=0,
                 use_ids=True, logfle=None)
         self.assertIn('isf_catalogue.py', cm.filename)
-        self.assertEqual(895, cm.lineno)
+        self.assertEqual(919, cm.lineno)
         
     def test_case05(self):
         """Testing the identification of doubtful events with use_kms"""


### PR DESCRIPTION
Changes to catalogue merging tools to keep the focal mechanism information from catalogues where we have it. 
Specifically: 
* changes to gcmt_catalogue so that information is retain in preprocessing steps
* changes to generic catalogue parser so that retain information is correctly read and passed on
* changes to isf_catalogue so that focal mechanism data is added to earthquake location information and passed to origin output
* changes to utils so that the final step of creating a csv checks if we have focal mechanism info and passes it on if we do
* updated line number in isf_catalogue_test