### PR TITLE
Modified context creation in gmpe_residuals to now use method require…

### DIFF
--- a/openquake/smt/residuals/gmpe_residuals.py
+++ b/openquake/smt/residuals/gmpe_residuals.py
@@ -572,7 +572,8 @@ class Residuals(object):
                     dist_idx = []
                     distance_type = 'rjb'
                     for idx, site in enumerate(dist_list):
-                        tmp_idx = np.argmin(np.abs(ctxs[idx][0][distance_type] - dist_list[idx]))
+                        tmp_idx = np.argmin(np.abs(ctxs[idx][0][
+                            distance_type] - dist_list[idx]))
                         dist_idx.append(tmp_idx)
                             
                     # Compute expected mean and sigma per site for each step
@@ -582,7 +583,8 @@ class Residuals(object):
                     tau = {}
                     phi = {}
                     for idx, site in enumerate(dist_list):
-                        [mean_per_step, stddev_per_step, tau_per_step, phi_per_step] = ctxm.get_mean_stds(ctxs[idx])
+                        [mean_per_step, stddev_per_step, tau_per_step,
+                         phi_per_step] = ctxm.get_mean_stds(ctxs[idx])
                         mean[idx] = mean_per_step[0][0][dist_idx[idx]]
                         stddev[idx] = stddev_per_step[0][0][dist_idx[idx]] 
                         tau[idx] = tau_per_step[0][0][dist_idx[idx]] 
@@ -614,8 +616,6 @@ class Residuals(object):
                         expected[gmpe][imtx][res_type] = stddev[i]
 
         context["Expected"] = expected
-        #print(context)
-        #print(expected)
         return context
 
     def calculate_residuals(self, context, normalise=True):

--- a/openquake/smt/residuals/gmpe_residuals.py
+++ b/openquake/smt/residuals/gmpe_residuals.py
@@ -43,6 +43,10 @@ import openquake.smt.intensity_measures as ims
 from openquake.smt.strong_motion_selector import SMRecordSelector
 from openquake.smt.sm_utils import convert_accel_units, check_gsim_list
 
+from openquake.hazardlib.contexts import ContextMaker
+from openquake.hazardlib.scalerel.wc1994 import WC1994
+from openquake.smt.comparison import utils_gmpes
+
 GSIM_LIST = get_available_gsims()
 GSIM_KEYS = set(GSIM_LIST)
 
@@ -483,24 +487,135 @@ class Residuals(object):
         for gmpe in self.gmpe_list:
             expected[gmpe] = OrderedDict([(imtx, {}) for imtx in self.imts])
             for imtx in self.imts:
-                gsim = self.gmpe_list[gmpe]
                 if "SA(" in imtx:
                     period = imt.from_string(imtx).period
                     if period < self.gmpe_sa_limits[gmpe][0] or\
                             period > self.gmpe_sa_limits[gmpe][1]:
                         expected[gmpe][imtx] = None
                         continue
-                mean, stddev = gsim.get_mean_and_stddevs(
-                    context["Ctx"],
-                    context["Ctx"],
-                    context["Ctx"],
-                    imt.from_string(imtx),
-                    self.types[gmpe][imtx])
-                expected[gmpe][imtx]["Mean"] = mean
-                for i, res_type in enumerate(self.types[gmpe][imtx]):
-                    expected[gmpe][imtx][res_type] = stddev[i]
+
+                # If NGAEast or KothaEtAl2020ESHM20 use diff. rupture context
+                if 'KothaEtAl2020ESHM20' in str(gmpe) or 'NGAEast' in str(gmpe):
+                
+                    # Create the rupture
+                    lon = context["Ctx"].lons[0]
+                    lat = context["Ctx"].lats[0]
+                    depth = context["Ctx"].depths[0]
+                    
+                    msr = WC1994()
+                    mag = float(context["Ctx"].mag)
+                    aratio = 2.0
+                    
+                    strike = context["Ctx"].strike
+                    dip = context["Ctx"].dip
+                    rake = context["Ctx"].rake
+                    trt = 'fake'
+                    ztor = context["Ctx"].ztor
+                    
+                    rup = utils_gmpes.get_rupture(lon, lat, depth, msr,
+                                                  mag= mag, aratio = aratio,
+                                                  strike = strike, dip = dip,
+                                                  rake = rake, trt = trt,
+                                                  ztor = ztor)
+            
+                    # Get the sites collection
+                    dist_list = context["Ctx"].rjb          
+                    step = 1
+                    from_point = 'TC'
+                    toward_azimuth = 90
+                    direction = 'positive'
+                    
+                    site_props = {}
+                    if 'KothaEtAl2020ESHM20' in gmpe:
+                        split_gmpe_str = str(gmpe).splitlines()
+                        
+                        for idx, strings in enumerate(split_gmpe_str):
+                            if 'eshm20_region' in split_gmpe_str[idx]:
+                                region_str = split_gmpe_str[idx]
+                            else:
+                                pass
+                        
+                        eshm20_region = float(region_str.split('=')[1])
+                        
+                        for idx, site in enumerate(dist_list):
+                            site_props[idx] = {'vs30': context['Ctx'].vs30[idx],
+                                               'z1pt0': context['Ctx'].z1pt0[idx],
+                                               'z2pt5': context['Ctx'].z2pt5[idx],
+                                               'backarc': False,
+                                               'vs30measured': True,
+                                               'region': eshm20_region}  
+                    else:
+                        for idx, site in enumerate(dist_list):
+                            site_props[idx]  = {'vs30': context['Ctx'].vs30[idx],
+                                                'z1pt0': context['Ctx'].z1pt0[idx],
+                                                'z2pt5': context['Ctx'].z2pt5[idx],
+                                                'backarc': False,
+                                                'vs30measured': True} 
+                    
+                    sites = {}
+                    for idx, site in enumerate(dist_list):
+                        sites[idx] = utils_gmpes.get_sites_from_rupture(
+                            rup, from_point, toward_azimuth, direction,
+                            dist_list[idx], step, site_props[idx])
+                    
+                    # Build the context maker and get the contexts
+                    mags_str = [f'{mag:.2f}']
+                    oqp = {'imtls': {k: [] for k in [imtx]}, 'mags': mags_str}
+                    gmm = [valid.gsim(str(gmpe).split('(')[0])]
+                    ctxm = ContextMaker('fake', gmm, oqp)
+                    
+                    ctxs = {}
+                    for idx, site in enumerate(dist_list):
+                        ctxs[idx] = list(ctxm.get_ctx_iter([rup], sites[idx]))
+           
+                    # Find the sites   
+                    dist_idx = []
+                    distance_type = 'rjb'
+                    for idx, site in enumerate(dist_list):
+                        tmp_idx = np.argmin(np.abs(ctxs[idx][0][distance_type] - dist_list[idx]))
+                        dist_idx.append(tmp_idx)
+                            
+                    # Compute expected mean and sigma per site for each step
+                    # and then find correct value using dist_idx
+                    mean = {}
+                    stddev = {}
+                    tau = {}
+                    phi = {}
+                    for idx, site in enumerate(dist_list):
+                        [mean_per_step, stddev_per_step, tau_per_step, phi_per_step] = ctxm.get_mean_stds(ctxs[idx])
+                        mean[idx] = mean_per_step[0][0][dist_idx[idx]]
+                        stddev[idx] = stddev_per_step[0][0][dist_idx[idx]] 
+                        tau[idx] = tau_per_step[0][0][dist_idx[idx]] 
+                        phi[idx] = phi_per_step[0][0][dist_idx[idx]] 
+                    
+                    # Reformat mean and sigma for residuals object
+                    mean = np.array(pd.Series(mean))
+                    stddev = np.array(pd.Series(stddev))
+                    tau = np.array(pd.Series(tau))
+                    phi = np.array(pd.Series(phi))
+                    gmpe_sigma = {'Total': stddev, 'Inter event': tau,
+                                  'Intra event': phi}
+
+                    expected[gmpe][imtx]["Mean"] = mean
+                    for i, res_type in enumerate(self.types[gmpe][imtx]):
+                        expected[gmpe][imtx][res_type] = gmpe_sigma[res_type]
+                        
+                else:   
+                    gsim = self.gmpe_list[gmpe]
+                    mean, stddev = gsim.get_mean_and_stddevs(
+                        context["Ctx"],
+                        context["Ctx"],
+                        context["Ctx"],
+                        imt.from_string(imtx),
+                        self.types[gmpe][imtx])
+                
+                    expected[gmpe][imtx]["Mean"] = mean
+                    for i, res_type in enumerate(self.types[gmpe][imtx]):
+                        expected[gmpe][imtx][res_type] = stddev[i]
 
         context["Expected"] = expected
+        #print(context)
+        #print(expected)
         return context
 
     def calculate_residuals(self, context, normalise=True):

--- a/openquake/smt/residuals/residual_plotter.py
+++ b/openquake/smt/residuals/residual_plotter.py
@@ -297,9 +297,17 @@ class ResidualPlot(ResidualHistogramPlot):
         ax.set_xlim(x_limit*-1,x_limit)
 
     def get_axis_title(self, res_data, res_type):
+        sigma_type = res_type
+        if res_type == 'Total':
+            sigma_type = 'Total Res.'
+        elif res_type == 'Inter-Event Res.':
+            sigma_type = 'Within event'
+        elif res_type == 'Intra-Event Res.':
+            sigma_type = 'Between event'
+        
         mean, stddev = res_data["mean"], res_data["stddev"]
         return "%s - %s\n Mean = %7.3f, Std Dev = %7.3f" % (str(
-            self.residuals.gmpe_list[self.gmpe]).split('(')[0],res_type,mean,
+            self.residuals.gmpe_list[self.gmpe]).split('(')[0],sigma_type,mean,
                                                             stddev)
     
 class LikelihoodPlot(ResidualHistogramPlot):
@@ -384,8 +392,15 @@ class ResidualScatterPlot(BaseResidualPlot):
         return -max_lim, max_lim
     
     def get_axis_title(self, res_data, res_type):
+        sigma_type = res_type
+        if res_type == 'Total':
+            sigma_type = 'Total Res.'
+        elif res_type == 'Inter event':
+            sigma_type = 'Between-Event Res.'
+        elif res_type == 'Intra event':
+            sigma_type = 'Within-Event Res.'
         return "%s - %s" %(str(self.residuals.gmpe_list[self.gmpe]).split('(')[0],
-             res_type)
+             sigma_type)
 
     def draw(self, ax, res_data, res_type):
         x, y = res_data['x'], res_data['y']
@@ -398,12 +413,26 @@ class ResidualScatterPlot(BaseResidualPlot):
             ax.semilogx(x, y, 'o', **pts_styling_kwargs)
             ax.scatter(res_data['bin_midpoints'],res_data['mean_res'],
                        marker = 's', color = 'b', label = 'mean', zorder = 4)
+            
+            ax.scatter(res_data['bin_midpoints'],res_data['mean_res'] + (
+                -1*res_data['sigma_res']), marker = 'x', color = 'b', zorder = 4)
+            ax.scatter(res_data['bin_midpoints'],res_data['mean_res'] + (
+                res_data['sigma_res']), marker = 'x', color = 'b',
+                label = '+/- 1 Std.', zorder = 4)
+            
             ax.plot(x_zero, zero_line, color = 'k', linestyle = '--',
                     linewidth = 1.25)
         else:
             ax.plot(x, y, 'o', **pts_styling_kwargs)
             ax.scatter(res_data['bin_midpoints'],res_data['mean_res'],
                        marker = 's', color = 'b', label = 'mean', zorder = 4)
+            
+            ax.scatter(res_data['bin_midpoints'],res_data['mean_res'] + (
+                -1*res_data['sigma_res']), marker = 'x', color = 'b', zorder = 4)
+            ax.scatter(res_data['bin_midpoints'],res_data['mean_res'] + (
+                res_data['sigma_res']), marker = 'x', color = 'b',
+                label = '+/- 1 Std.', zorder = 4)
+            
             ax.plot(x_zero, zero_line, color = 'k', linestyle = '--',
                     linewidth = 1.25)
         ax.legend(loc = 'upper right', fontsize = 'x-small')


### PR DESCRIPTION
…d for eshm20 or NGAEast (still need to implement NGAEast and subsequently Al-Atik modifiable sigma). The original method is still retained for non-NGAEast/K20 GMPEs because it is more efficient, and therefore better to use if not required. The results between KothaEtAl2020regional and KothaEtAl2020ESHM20 are favourable for each tested region.

