### PR TITLE
Implementation of ESHM20, NGAEast and other modifiable GMPEs within S…

### DIFF
--- a/docsrc/contents/smt.rst
+++ b/docsrc/contents/smt.rst
@@ -117,6 +117,9 @@ We can specify the inputs to perform a residual analysis within the smt are spec
             d_sigma = 100
             kappa0 = 0.04
         
+        [models.YenierAtkinson2015BSSA]
+        sigma_model = 'al_atik_2015_sigma'
+        
         [imts]
         imt_list = ['PGA', 'SA(0.2)', 'SA(0.5)', 'SA(1.0']    
 

--- a/openquake/smt/comparison/utils_compare_gmpes.py
+++ b/openquake/smt/comparison/utils_compare_gmpes.py
@@ -84,7 +84,6 @@ def plot_trellis_util(rake, strike, dip, depth, Z1, Z25, Vs30, region,
                                                                task = 'comparison')
                 else:
                     pass
-                    
 
                 mean, std, distances = att_curves(gmm,depth[l],m,aratio_g,
                                                  strike_g,dip_g,rake,Vs30,
@@ -228,6 +227,7 @@ def plot_trellis_util(rake, strike, dip, depth, Z1, Z25, Vs30, region,
             pass
     display(trellis_value_df)
     trellis_value_df.to_csv(os.path.join(output_directory, 'trellis_values.csv'))
+    
     
 def plot_spectra_util(rake, strike, dip, depth, Z1, Z25, Vs30, region,
                       max_period, mag_list, dist_list, gmpe_list, aratio, Nstd,
@@ -426,9 +426,9 @@ def plot_spectra_util(rake, strike, dip, depth, Z1, Z25, Vs30, region,
                         store_lt_mean_per_dist_mag[i,m])), '-']
     else:
         pass
-                    
     display(spectra_value_df)
     spectra_value_df.to_csv(os.path.join(output_directory, 'spectra_values.csv'))
+
 
 def compute_matrix_gmpes(imt_list, mag_list, gmpe_list, rake, strike,
                          dip, depth, Z1, Z25, Vs30, region,  maxR,  aratio,
@@ -480,7 +480,6 @@ def compute_matrix_gmpes(imt_list, mag_list, gmpe_list, rake, strike,
 
             matrix_medians[:][g]= medians
         mtxs_median[n] = matrix_medians
-    
     return mtxs_median
 
 def plot_euclidean_util(imt_list, gmpe_list, mtxs, namefig, mtxs_type):
@@ -547,9 +546,9 @@ def plot_euclidean_util(imt_list, gmpe_list, mtxs, namefig, mtxs_type):
 
     pyplot.savefig(namefig, bbox_inches='tight',dpi=200,pad_inches = 0.2)
     pyplot.show()
-    pyplot.tight_layout()
-        
+    pyplot.tight_layout()        
     return matrix_Dist
+
     
 def plot_sammons_util(imt_list, gmpe_list, mtxs, namefig, custom_color_flag,
                       custom_color_list, mtxs_type):
@@ -615,7 +614,6 @@ def plot_sammons_util(imt_list, gmpe_list, mtxs, namefig, custom_color_flag,
     pyplot.savefig(namefig, bbox_inches='tight',dpi=200,pad_inches = 0.2)
     pyplot.show()
     pyplot.tight_layout()
-    
     return coo
 
 def plot_cluster_util(imt_list, gmpe_list, mtxs, namefig, mtxs_type):
@@ -684,5 +682,4 @@ def plot_cluster_util(imt_list, gmpe_list, mtxs, namefig, mtxs_type):
     pyplot.savefig(namefig, bbox_inches='tight',dpi=200,pad_inches = 0.4)
     pyplot.show()
     pyplot.tight_layout() 
-    
     return matrix_Z

--- a/openquake/smt/comparison/utils_compare_gmpes.py
+++ b/openquake/smt/comparison/utils_compare_gmpes.py
@@ -82,6 +82,8 @@ def plot_trellis_util(rake, strike, dip, depth, Z1, Z25, Vs30, region,
                                                  strike_g,dip_g,rake,Vs30,
                                                  Z1,Z25,maxR,step,i,1,
                                                  eshm20_region) 
+                mean = mean[0][0]
+                std = std[0][0]
                 
                 pyplot.plot(distances, np.exp(mean), color=col,
                             linewidth=2, linestyle='-', label=gmpe)
@@ -332,6 +334,7 @@ def plot_spectra_util(rake, strike, dip, depth, Z1, Z25, Vs30, region,
                                                     Z1,Z25,300,0.1,imt,1,
                                                     eshm20_region) 
                     
+                    mu = mu[0][0]
                     f = interpolate.interp1d(distances,mu)
                     rs_50p_dist = np.exp(f(i))
                     

--- a/openquake/smt/comparison/utils_compare_gmpes.py
+++ b/openquake/smt/comparison/utils_compare_gmpes.py
@@ -31,6 +31,7 @@ from IPython.display import display
 from openquake.smt.comparison.sammons import sammon
 from openquake.hazardlib import valid
 from openquake.hazardlib.imt import from_string
+from openquake.smt.sm_utils import al_atik_sigma_check
 from openquake.smt.comparison.utils_gmpes import att_curves, _get_z1, _get_z25, _param_gmpes
 
 def plot_trellis_util(rake, strike, dip, depth, Z1, Z25, Vs30, region,
@@ -77,6 +78,13 @@ def plot_trellis_util(rake, strike, dip, depth, Z1, Z25, Vs30, region,
 
                 gmm = valid.gsim(gmpe)
                 col=colors[g]
+
+                if not Nstd ==0:
+                    gmm, gmpe_sigma_flag = al_atik_sigma_check(gmpe, str(i),
+                                                               task = 'comparison')
+                else:
+                    pass
+                    
 
                 mean, std, distances = att_curves(gmm,depth[l],m,aratio_g,
                                                  strike_g,dip_g,rake,Vs30,
@@ -210,7 +218,6 @@ def plot_trellis_util(rake, strike, dip, depth, Z1, Z25, Vs30, region,
     if Nstd == 0:
         trellis_value_df = pd.DataFrame(store_trellis_values,
                                         index = ['Mean (g)', 'Distance (km)'])
-        
         if lt_weights != None:
             for n, i in enumerate(imt_list): #iterate though imt_list
                 for l, m in enumerate(mag_list):  #iterate through mag_list
@@ -219,9 +226,7 @@ def plot_trellis_util(rake, strike, dip, depth, Z1, Z25, Vs30, region,
                                                           distances]                                                         
         else:
             pass
-                                                           
-    display(trellis_value_df)                                                
-    
+    display(trellis_value_df)
     trellis_value_df.to_csv(os.path.join(output_directory, 'trellis_values.csv'))
     
 def plot_spectra_util(rake, strike, dip, depth, Z1, Z25, Vs30, region,
@@ -328,7 +333,6 @@ def plot_spectra_util(rake, strike, dip, depth, Z1, Z25, Vs30, region,
                 rs_50p, sigma = [], []
                 
                 for k, imt in enumerate(imt_list): 
-
                     mu, std, distances = att_curves(gmm,depth[l],m,aratio_g,
                                                     strike_g,dip_g,rake,Vs30,
                                                     Z1,Z25,300,0.1,imt,1,
@@ -382,7 +386,6 @@ def plot_spectra_util(rake, strike, dip, depth, Z1, Z25, Vs30, region,
             logic_tree_config = 'GMPE logic tree'
             
             if store_lt_branch_values != {}:
-                       
                 lt_df = pd.DataFrame(store_lt_branch_values, index = ['mean'])
                 
                 weighted_mean_per_gmpe = {}
@@ -461,8 +464,9 @@ def compute_matrix_gmpes(imt_list, mag_list, gmpe_list, rake, strike,
                 strike_g, dip_g, depth_g, aratio_g = _param_gmpes(
                     gmpe,strike, dip, depth[l], aratio, rake) 
 
-                gmm = valid.gsim(gmpe)
-                
+                gmm, gmpe_sigma_flag = al_atik_sigma_check(gmpe, str(i),
+                                                           task = 'comparison')
+
                 mean, std, distances = att_curves(gmm,depth[l],m,aratio_g,
                                                   strike_g,dip_g,rake,Vs30,Z1,
                                                   Z25,maxR,step,i,1,eshm20_region) 

--- a/openquake/smt/comparison/utils_gmpes.py
+++ b/openquake/smt/comparison/utils_gmpes.py
@@ -199,8 +199,6 @@ def _param_gmpes(gmpes, strike, dip, depth, aratio, rake):
         dip_s = dip
 
     if depth == -999:
-        print(gmpes)
-        
         if str(valid.gsim(gmpes).DEFINED_FOR_TECTONIC_REGION_TYPE) == 'TRT.SUBDUCTION_INTERFACE':
             depth_s = 30
         elif str(valid.gsim(gmpes).DEFINED_FOR_TECTONIC_REGION_TYPE) == 'TRT.SUBDUCTION_INTRASLAB':

--- a/openquake/smt/residuals/gmpe_residuals.py
+++ b/openquake/smt/residuals/gmpe_residuals.py
@@ -572,7 +572,7 @@ class Residuals(object):
                 np.min(dist_list)-0.001, site_props[idx])
         
         # Check if need to use Al-Atik (2015) sigma model
-        gmpe, sigma_model_flag = al_atik_sigma_check(gmpe, imtx)
+        gmpe, sigma_model_flag = al_atik_sigma_check(gmpe, imtx, task = 'residual')
         
         # Rebuild the context maker and get the contexts
         mag = rd['mag']

--- a/openquake/smt/residuals/gmpe_residuals.py
+++ b/openquake/smt/residuals/gmpe_residuals.py
@@ -45,6 +45,7 @@ from openquake.smt.sm_utils import convert_accel_units, check_gsim_list
 from openquake.hazardlib.contexts import ContextMaker
 from openquake.hazardlib.scalerel.wc1994 import WC1994
 from openquake.smt.comparison import utils_gmpes
+from openquake.hazardlib.gsim.mgmpe import modifiable_gmpe
 
 GSIM_LIST = get_available_gsims()
 GSIM_KEYS = set(GSIM_LIST)
@@ -492,7 +493,6 @@ class Residuals(object):
                             period > self.gmpe_sa_limits[gmpe][1]:
                         expected[gmpe][imtx] = None
                         continue 
-                
                 ctxm, ctxs, dist_idx = self._get_ctx_for_expected_motions(
                     context, gmpe, imtx)
         
@@ -524,11 +524,13 @@ class Residuals(object):
         Reformat context for computation of expected ground-motion
         """
         # Reformat the rupture
+        trt = self.gmpe_list[gmpe].DEFINED_FOR_TECTONIC_REGION_TYPE
+        
         rd = {'lon':context["Ctx"].lons[0], 'lat': context["Ctx"].lats[0],
               'depth': context["Ctx"].depths[0], 'msr': WC1994(),
               'mag': context["Ctx"].mag, 'aratio': 2.0, 'strike': context[
                   "Ctx"].strike, 'dip': context["Ctx"].dip, 'rake': context[
-                      "Ctx"].rake, 'trt': 'fake', 'ztor': context['Ctx'].ztor}
+                      "Ctx"].rake, 'trt': trt, 'ztor': context['Ctx'].ztor}
 
         rup = utils_gmpes.get_rupture(rd['lon'], rd['lat'], rd['depth'],
                                       rd['msr'], rd['mag'], rd['aratio'],
@@ -1015,7 +1017,8 @@ class Residuals(object):
         self.edr_values_wrt_imt = OrderedDict([(gmpe, {}) for 
                                                gmpe in self.gmpe_list])
         for gmpe in self.gmpe_list:
-            obs_wrt_imt, expected_wrt_imt, stddev_wrt_imt = self._get_edr_gmpe_information_wrt_spectral_period(gmpe)
+            obs_wrt_imt, expected_wrt_imt, stddev_wrt_imt = \
+                self._get_edr_gmpe_information_wrt_spectral_period(gmpe)
             results = self._get_edr_wrt_spectral_period(obs_wrt_imt,
                                     expected_wrt_imt,
                                     stddev_wrt_imt,

--- a/openquake/smt/residuals/gmpe_residuals.py
+++ b/openquake/smt/residuals/gmpe_residuals.py
@@ -576,7 +576,7 @@ class Residuals(object):
         mag = rd['mag']
         mag_str = [f'{mag:.2f}']
         oqp = {'imtls': {k: [] for k in [imtx]}, 'mags': mag_str}
-        ctxm = ContextMaker('fake', [self.gmpe_list[gmpe]], oqp)
+        ctxm = ContextMaker(trt, [self.gmpe_list[gmpe]], oqp)
         ctxs = {}
         for idx, site in enumerate(dist_list):
             ctxs[idx] = list(ctxm.get_ctx_iter([rup], sites[idx]))

--- a/openquake/smt/residuals/gmpe_residuals.py
+++ b/openquake/smt/residuals/gmpe_residuals.py
@@ -537,16 +537,21 @@ class Residuals(object):
                                       rd['trt'], rd['ztor'])
 
         # Reformat the sites collection
-        dist_list = context["Ctx"].rjb   
+        dist_list = context["Ctx"].rjb
+        for idx, site in enumerate(dist_list):
+            if dist_list[idx] == 0.:
+                dist_list[idx] = 0.001
+            else:
+                pass
         site_props = {}
         if 'KothaEtAl2020ESHM20' in gmpe:
-            split_gmpe_str = str(gmpe).splitlines()          
-            for idx, strings in enumerate(split_gmpe_str):
-                if 'eshm20_region' in split_gmpe_str[idx]:
-                    region_str = split_gmpe_str[idx]
+            split_gmpe_str = str(gmpe).split('\n')
+            for idx_string, strings in enumerate(split_gmpe_str):
+                if 'eshm20_region' in split_gmpe_str[idx_string]:
+                    region_str = split_gmpe_str[idx_string]
                 else:
                     pass
-            eshm20_region = float(region_str.split('=')[1])
+            eshm20_region = float(region_str.split('=')[1].replace(')',''))
             for idx, site in enumerate(dist_list):
                 site_props[idx] = {'vs30': context['Ctx'].vs30[idx],
                                    'z1pt0': context['Ctx'].z1pt0[idx],
@@ -569,8 +574,8 @@ class Residuals(object):
                 azimuth =  context['Ctx'].azimuth[idx]
             sites[idx] = utils_gmpes.get_sites_from_rupture(
                 rup, 'TC', azimuth ,'positive', dist_list[idx],
-                np.min(dist_list)-0.001, site_props[idx])
-        
+                np.min(dist_list)-0.0001, site_props[idx])
+       
         # Check if need to use Al-Atik (2015) sigma model
         gmpe, sigma_model_flag = al_atik_sigma_check(gmpe, imtx, task = 'residual')
         

--- a/openquake/smt/residuals/gmpe_residuals.py
+++ b/openquake/smt/residuals/gmpe_residuals.py
@@ -580,6 +580,8 @@ class Residuals(object):
         oqp = {'imtls': {k: [] for k in [imtx]}, 'mags': mag_str}
         if sigma_model_flag == True:
             ctxm = ContextMaker(trt, [gmpe], oqp)
+        elif sigma_model_flag == False and '[ModifiableGMPE]' in str(gmpe):
+            ctxm = ContextMaker(trt, [gmpe], oqp)
         else:
             ctxm = ContextMaker(trt, [self.gmpe_list[gmpe]], oqp)
         ctxs = {}

--- a/openquake/smt/sm_utils.py
+++ b/openquake/smt/sm_utils.py
@@ -480,9 +480,9 @@ def vs30_to_z2pt5_cb14(vs30, japan=False):
     
 def al_atik_sigma_check(gmpe, imtx, task):
     """
-    Check if Al-Atik (2015) sigma model should be implemented for a given GMPE
-    and implement if specified. Also provides a warning if GMPE sigma is not
-    provided by the specified GMPE.
+    Check if sigma is provided for a given GMPE and implement Al-Atik (2015)
+    sigma model if specified. Also provides a warning if GMPE sigma is not
+    provided by the specified GMPE. 
     :param gmpe:
         GMPE to check model sigma is provided, and to check if Al-Atik (2015)
         sigma model should be implemented for
@@ -517,7 +517,6 @@ def al_atik_sigma_check(gmpe, imtx, task):
     
     # Get model sigma and if not provided implement Al-Atik (2015) if specified
     tmp_mean, tmp_std, tmp_tau, tmp_phi = ctxm.get_mean_stds(ctxs)
-    
     tmp_gmpe = str(tmp_gmm).split(']')[0].replace('[','')
     kwargs = {'gmpe': {tmp_gmpe: {'sigma_model_alatik2015': {}}},
               'sigma_model_alatik2015': {}}

--- a/openquake/smt/sm_utils.py
+++ b/openquake/smt/sm_utils.py
@@ -503,7 +503,7 @@ def al_atik_sigma_check(gmpe, imtx, task):
               'vs30measured': True, 'region': 0}  
     else:
         sp = {'vs30': 800, 'z1pt0': z1pt0, 'z2pt5': z1pt5, 'backarc': False,
-              'vs30measured': True, 'region': 0}  
+              'vs30measured': True}  
             
     tmp_site = get_sites_from_rupture(tmp_rup, 'TC', 90, 'positive', 100, 5, sp)
     

--- a/openquake/smt/sm_utils.py
+++ b/openquake/smt/sm_utils.py
@@ -495,11 +495,13 @@ def al_atik_sigma_check(gmpe, imtx, task = 'residual'):
     # Construct a generic context (M = 5.5, D = 100km) to check if sigma provided 
     tmp_rup = get_rupture(20, 40, 15, WC1994(), 5.5, 2, 0, 90, 0, 'fake', None)
 
+    z1pt0 = vs30_to_z1pt0_cy14(800)
+    z1pt5 = vs30_to_z2pt5_cb14(800)
     if 'KothaEtAl2020ESHM20' in str(gmpe):
-        sp = {'vs30': 800, 'z1pt0': 0.05 , 'z2pt5': 0.10, 'backarc': False,
+        sp = {'vs30': 800, 'z1pt0': z1pt0, 'z2pt5': z1pt5, 'backarc': False,
               'vs30measured': True, 'region': 0}  
     else:
-        sp = {'vs30': 800, 'z1pt0': 0.05, 'z2pt5': 0.10, 'backarc': False,
+        sp = {'vs30': 800, 'z1pt0': z1pt0, 'z2pt5': z1pt5, 'backarc': False,
               'vs30measured': True, 'region': 0}  
             
     tmp_site = get_sites_from_rupture(tmp_rup, 'TC', 90, 'positive', 100, 5, sp)
@@ -522,7 +524,7 @@ def al_atik_sigma_check(gmpe, imtx, task = 'residual'):
                 kwargs = {'gmpe': {tmp_gmpe: {'sigma_model_alatik2015': {}}},
                           'sigma_model_alatik2015': {}}
                 gmpe = mgmpe.ModifiableGMPE(**kwargs)
-                warnings.warn('Al Atik (2015) sigma model has been implemented for %s GMPE.'
+                warnings.warn('Al Atik (2015) sigma model has been implemented for %s GMPE by the user.'
                     %tmp_gmm, stacklevel = 100)
             else:
                 warnings.warn('A sigma model is not provided by default for %s GMPE.'

--- a/openquake/smt/sm_utils.py
+++ b/openquake/smt/sm_utils.py
@@ -522,7 +522,7 @@ def al_atik_sigma_check(gmpe, imtx, task):
     kwargs = {'gmpe': {tmp_gmpe: {'sigma_model_alatik2015': {}}},
               'sigma_model_alatik2015': {}}
     
-    msg1 = 'Al Atik (2015) sigma model has been implemented for %s GMPE by the user.' %tmp_gmpe
+    msg1 = 'Al-Atik (2015) sigma model has been implemented for an implementation of %s by the user.' %tmp_gmpe
     msg2 = 'A sigma model is not provided by default for %s GMPE.' %tmp_gmpe
     
     if tmp_std.all() == 0:

--- a/openquake/smt/sm_utils.py
+++ b/openquake/smt/sm_utils.py
@@ -29,12 +29,19 @@ import numpy as np
 from scipy.integrate import cumtrapz
 from scipy.constants import g
 from math import sqrt, pi, sin, cos
+import warnings
 
+from openquake.hazardlib import valid
 from openquake.hazardlib.geo import PlanarSurface
 from openquake.hazardlib.gsim import get_available_gsims
 from openquake.hazardlib.scalerel.peer import PeerMSR
 from openquake.hazardlib.gsim.gmpe_table import GMPETable
 from openquake.hazardlib.gsim.base import GMPE
+from openquake.hazardlib.gsim.mgmpe import modifiable_gmpe as mgmpe
+from openquake.hazardlib.contexts import ContextMaker
+from openquake.hazardlib.scalerel.wc1994 import WC1994
+from openquake.smt.comparison.utils_gmpes import get_rupture, get_sites_from_rupture
+
 
 if sys.version_info[0] >= 3:
     import pickle
@@ -470,3 +477,59 @@ def vs30_to_z2pt5_cb14(vs30, japan=False):
         return np.exp(5.359 - 1.102 * np.log(vs30))
     else:
         return np.exp(7.089 - 1.144 * np.log(vs30))
+    
+def al_atik_sigma_check(gmpe, imtx):
+    """
+    Check if Al-Atik (2015) sigma model should be implemented for a given GMPE
+    and implement if specified. Also provides a warning if GMPE sigma is not
+    provided by the specified GMPE.
+    :param gmpe:
+        GMPE to check model sigma is provided, and to check if Al-Atik (2015)
+        sigma model should be implemented for
+    :param imtx:
+        Intensity measure to perform sigma checks for with the specified GMPE
+    """
+    # Construct a generic context (M = 5.5, D = 100km) to check if sigma provided 
+    tmp_rup = get_rupture(20, 40, 15, WC1994(), 5.5, 2, 0, 90, 0, 'fake', None)
+
+    if 'KothaEtAl2020ESHM20' in str(gmpe):
+        sp = {'vs30': 800, 'z1pt0': 0.05 , 'z2pt5': 0.10, 'backarc': False,
+              'vs30measured': True, 'region': 0}  
+    else:
+        sp = {'vs30': 800, 'z1pt0': 0.05, 'z2pt5': 0.10, 'backarc': False,
+              'vs30measured': True, 'region': 0}  
+            
+    tmp_site = get_sites_from_rupture(tmp_rup, 'TC', 90, 'positive', 100, 5, sp)
+    
+    oqp = {'imtls': {k: [] for k in [imtx]}, 'mags': [f'{5.5:.2f}']}
+    if '_toml=' in str(gmpe):
+        tmp_gmm = valid.gsim(str(gmpe).split('_toml=')[1].replace(')',''))
+    else:
+        tmp_gmm = valid.gsim(gmpe)
+    ctxm = ContextMaker('fake', [tmp_gmm], oqp)
+    ctxs = list(ctxm.get_ctx_iter([tmp_rup], tmp_site))
+    
+    # Get model sigma and if not provided implement Al-Atik (2015) if specified
+    tmp_mean, tmp_std, tmp_tau, tmp_phi = ctxm.get_mean_stds(ctxs)
+    if tmp_std.all() == 0:
+        sigma_model_flag = True
+        if 'toml=' in str(gmpe):
+            if 'al_atik_2015_sigma' in str(gmpe):
+                tmp_gmpe = str(tmp_gmm).split(']')[0].replace('[','')
+                kwargs = {'gmpe': {tmp_gmpe: {'sigma_model_alatik2015': {}}},
+                          'sigma_model_alatik2015': {}}
+                gmpe = mgmpe.ModifiableGMPE(**kwargs)
+                warnings.warn('Al Atik (2015) sigma model has been implemented for %s GMPE.'
+                    %tmp_gmm, stacklevel = 100)
+            else:
+                warnings.warn('A sigma model is not provided by default for %s GMPE.'
+                              %tmp_gmm, stacklevel = 100)
+                gmpe = tmp_gmm
+        else:
+            warnings.warn('A sigma model is not provided by default for %s GMPE.'
+                          %tmp_gmm, stacklevel = 100)
+            gmpe = valid.gsim(gmpe)
+            
+    else:
+        sigma_model_flag = False
+    return gmpe, sigma_model_flag

--- a/openquake/smt/tests/residuals/gmpe_ranking_metrics_wrt_imt_test.py
+++ b/openquake/smt/tests/residuals/gmpe_ranking_metrics_wrt_imt_test.py
@@ -41,13 +41,10 @@ class gmpe_ranking_metrics_wrt_imt_test(unittest.TestCase):
     metadata = os.path.join(metadata_directory, metadata_file)
     sm_database = pickle.load(open(metadata,"rb"))
 
-    # Specify path to .toml file with gmpes + imts to consider
-    filename = os.path.join(DATA,'data','test_gmpe_metrics.toml')
-
-
     gmpe_list = ['ChiouYoungs2014','CampbellBozorgnia2014',
                  'BooreEtAl2014','AbrahamsonEtAl2014']
     imts = ['PGA', 'SA(1.0)']
+    
     residuals = res.Residuals(gmpe_list, imts)
     residuals.get_residuals(sm_database)
 

--- a/openquake/smt/tests/sm_utils_test.py
+++ b/openquake/smt/tests/sm_utils_test.py
@@ -163,9 +163,10 @@ class SmUtilsTestCase(unittest.TestCase):
                 self.assertTrue(gmpe_outputted == inputted_gmpe) # Check not modified GMPE
                 
         # If from .toml only YA15 should be flagged and Al-Atik 2015 added
-        DATA = os.path.abspath('')
-        residuals = res.Residuals.from_toml(os.path.join(DATA,
-                                                         'sm_utils_test.toml'))
+        BASE_DATA_PATH = os.path.join(os.path.dirname(__file__))
+        filename = os.path.join(BASE_DATA_PATH, 'sm_utils_test.toml')
+        residuals = res.Residuals.from_toml(filename)
+        
         for idx, inputted_gmpe in enumerate(residuals.gmpe_list):
             gmpe_outputted, gmpe_sigma_flag = al_atik_sigma_check(inputted_gmpe,
                                                                   imts[0], task

--- a/openquake/smt/tests/sm_utils_test.py
+++ b/openquake/smt/tests/sm_utils_test.py
@@ -152,7 +152,8 @@ class SmUtilsTestCase(unittest.TestCase):
         gmpe_list = ['YenierAtkinson2015BSSA', 'BooreEtAl2014']
         imts = ['PGA']
         for idx, inputted_gmpe in enumerate(gmpe_list):
-            gmpe_outputted, gmpe_sigma_flag = al_atik_sigma_check(inputted_gmpe, imts[0])
+            gmpe_outputted, gmpe_sigma_flag = al_atik_sigma_check(inputted_gmpe,
+                                                                  imts[0])
             if idx == 0:
                 self.assertTrue(gmpe_sigma_flag == True) # Check flagged
                 self.assertTrue(gmpe_outputted == valid.gsim(inputted_gmpe)) # Check not modified GMPE
@@ -163,13 +164,13 @@ class SmUtilsTestCase(unittest.TestCase):
         # If from .toml only YA15 should be flagged and Al-Atik 2015 added
         residuals = res.Residuals.from_toml('sm_utils_test.toml')
         for idx, inputted_gmpe in enumerate(residuals.gmpe_list):
-            #inputted_gmpe = valid.gsim(str(inputted_gmpe).split('_toml=')[1].replace(')',''))
-            print(inputted_gmpe)
-            gmpe_outputted, gmpe_sigma_flag = al_atik_sigma_check(inputted_gmpe, imts[0])
+            gmpe_outputted, gmpe_sigma_flag = al_atik_sigma_check(inputted_gmpe,
+                                                                  imts[0])
             if idx == 0:
                 self.assertTrue(gmpe_sigma_flag == True) # Check flagged
                 # Get expected modified GMPE
-                tmp_gmm = valid.gsim(str(inputted_gmpe).split('_toml=')[1].replace(')',''))
+                tmp_gmm = valid.gsim(str(inputted_gmpe).split('_toml=')[
+                    1].replace(')',''))
                 tmp_gmpe = str(tmp_gmm).split(']')[0].replace('[','')
                 kwargs = {'gmpe': {tmp_gmpe: {'sigma_model_alatik2015': {}}},
                           'sigma_model_alatik2015': {}}
@@ -177,13 +178,9 @@ class SmUtilsTestCase(unittest.TestCase):
                 self.assertTrue(gmpe_outputted == mgmpe.ModifiableGMPE(**kwargs)) # Check is modified GMPE
             if idx == 1:
                 self.assertTrue(gmpe_sigma_flag == False) # Check not flagged
-                #self.assertTrue(gmpe_outputted == inputted_gmpe) # Check not modified GMPE
-
-        
-        
-     
-        
+                self.assertTrue(gmpe_outputted == inputted_gmpe) # Check not modified GMPE
                     
+                
 if __name__ == "__main__":
     #import sys;sys.argv = ['', 'Test.testName']
     unittest.main()

--- a/openquake/smt/tests/sm_utils_test.py
+++ b/openquake/smt/tests/sm_utils_test.py
@@ -146,14 +146,14 @@ class SmUtilsTestCase(unittest.TestCase):
         are checked correctly, and that Al-Atik (2015) sigma model is correctly
         implemented if required
         """
-        
         # If from gmpe_list, only YA15 should be flagged, but no sigma model
         # should be implemented (must be specified in input .toml)
         gmpe_list = ['YenierAtkinson2015BSSA', 'BooreEtAl2014']
         imts = ['PGA']
         for idx, inputted_gmpe in enumerate(gmpe_list):
             gmpe_outputted, gmpe_sigma_flag = al_atik_sigma_check(inputted_gmpe,
-                                                                  imts[0])
+                                                                  imts[0], task
+                                                                  = 'residual')
             if idx == 0:
                 self.assertTrue(gmpe_sigma_flag == True) # Check flagged
                 self.assertTrue(gmpe_outputted == valid.gsim(inputted_gmpe)) # Check not modified GMPE
@@ -165,7 +165,8 @@ class SmUtilsTestCase(unittest.TestCase):
         residuals = res.Residuals.from_toml('sm_utils_test.toml')
         for idx, inputted_gmpe in enumerate(residuals.gmpe_list):
             gmpe_outputted, gmpe_sigma_flag = al_atik_sigma_check(inputted_gmpe,
-                                                                  imts[0])
+                                                                  imts[0], task
+                                                                  = 'residual')
             if idx == 0:
                 self.assertTrue(gmpe_sigma_flag == True) # Check flagged
                 # Get expected modified GMPE

--- a/openquake/smt/tests/sm_utils_test.py
+++ b/openquake/smt/tests/sm_utils_test.py
@@ -18,17 +18,14 @@
 """
 Tests the GM database parsing and selection
 """
-import os
-# import shutil
-import sys
-from datetime import datetime
-# import json
-# import pprint
 import unittest
 import numpy as np
 from scipy.constants import g
 
-from openquake.smt.sm_utils import convert_accel_units, SCALAR_XY
+from openquake.hazardlib import valid
+from openquake.smt.residuals import gmpe_residuals as res
+from openquake.smt.sm_utils import convert_accel_units, SCALAR_XY, al_atik_sigma_check
+from openquake.hazardlib.gsim.mgmpe import modifiable_gmpe as mgmpe
 
 
 # OLD IMPLEMENTATION OF CONVERT ACCELERATION UNITS. USED HERE
@@ -142,6 +139,50 @@ class SmUtilsTestCase(unittest.TestCase):
                     self.assertTrue(equals)
                 except AssertionError:
                     asd = 9
+
+    def test_al_atik_sigma_check(self):
+        """
+        Check that sigma for GMPEs inputted from both gmpe_list and .toml file
+        are checked correctly, and that Al-Atik (2015) sigma model is correctly
+        implemented if required
+        """
+        
+        # If from gmpe_list, only YA15 should be flagged, but no sigma model
+        # should be implemented (must be specified in input .toml)
+        gmpe_list = ['YenierAtkinson2015BSSA', 'BooreEtAl2014']
+        imts = ['PGA']
+        for idx, inputted_gmpe in enumerate(gmpe_list):
+            gmpe_outputted, gmpe_sigma_flag = al_atik_sigma_check(inputted_gmpe, imts[0])
+            if idx == 0:
+                self.assertTrue(gmpe_sigma_flag == True) # Check flagged
+                self.assertTrue(gmpe_outputted == valid.gsim(inputted_gmpe)) # Check not modified GMPE
+            if idx == 1:
+                self.assertTrue(gmpe_sigma_flag == False) # Check not flagged
+                self.assertTrue(gmpe_outputted == inputted_gmpe) # Check not modified GMPE
+                
+        # If from .toml only YA15 should be flagged and Al-Atik 2015 added
+        residuals = res.Residuals.from_toml('sm_utils_test.toml')
+        for idx, inputted_gmpe in enumerate(residuals.gmpe_list):
+            #inputted_gmpe = valid.gsim(str(inputted_gmpe).split('_toml=')[1].replace(')',''))
+            print(inputted_gmpe)
+            gmpe_outputted, gmpe_sigma_flag = al_atik_sigma_check(inputted_gmpe, imts[0])
+            if idx == 0:
+                self.assertTrue(gmpe_sigma_flag == True) # Check flagged
+                # Get expected modified GMPE
+                tmp_gmm = valid.gsim(str(inputted_gmpe).split('_toml=')[1].replace(')',''))
+                tmp_gmpe = str(tmp_gmm).split(']')[0].replace('[','')
+                kwargs = {'gmpe': {tmp_gmpe: {'sigma_model_alatik2015': {}}},
+                          'sigma_model_alatik2015': {}}
+                inputted_gmpe = mgmpe.ModifiableGMPE(**kwargs)
+                self.assertTrue(gmpe_outputted == mgmpe.ModifiableGMPE(**kwargs)) # Check is modified GMPE
+            if idx == 1:
+                self.assertTrue(gmpe_sigma_flag == False) # Check not flagged
+                #self.assertTrue(gmpe_outputted == inputted_gmpe) # Check not modified GMPE
+
+        
+        
+     
+        
                     
 if __name__ == "__main__":
     #import sys;sys.argv = ['', 'Test.testName']

--- a/openquake/smt/tests/sm_utils_test.py
+++ b/openquake/smt/tests/sm_utils_test.py
@@ -18,6 +18,7 @@
 """
 Tests the GM database parsing and selection
 """
+import os
 import unittest
 import numpy as np
 from scipy.constants import g
@@ -162,7 +163,9 @@ class SmUtilsTestCase(unittest.TestCase):
                 self.assertTrue(gmpe_outputted == inputted_gmpe) # Check not modified GMPE
                 
         # If from .toml only YA15 should be flagged and Al-Atik 2015 added
-        residuals = res.Residuals.from_toml('sm_utils_test.toml')
+        DATA = os.path.abspath('')
+        residuals = res.Residuals.from_toml(os.path.join(DATA,
+                                                         'sm_utils_test.toml'))
         for idx, inputted_gmpe in enumerate(residuals.gmpe_list):
             gmpe_outputted, gmpe_sigma_flag = al_atik_sigma_check(inputted_gmpe,
                                                                   imts[0], task

--- a/openquake/smt/tests/sm_utils_test.toml
+++ b/openquake/smt/tests/sm_utils_test.toml
@@ -1,0 +1,9 @@
+[models]
+
+[models.YenierAtkinson2015BSSA]
+sigma_model = 'al_atik_2015_sigma'
+
+[models.BooreEtAl2014]
+
+[imts]
+imt_list = ["PGA"]


### PR DESCRIPTION
…MT residuals calculations. A single function has been added called _get_ctx_for_expected_motions. This function is called from within get_expected_motions. It reformats the context into a context with exactly the same information which is useable by gmpe_table GMPEs and enables specification of ESHM20_region. The tests within SMT for checking residual values and residuals storage (the values are provided in the tests and then the values outputted by the SMT are checked against them) are all passed. This new function is called for all GMPEs (rather than just those requiring it) for uniformity, and does not affect the outputted residuals or computation time.