### PR TITLE
quick fix for if distances returned by att_curves function are less t…

### DIFF
--- a/docsrc/contents/smt.rst
+++ b/docsrc/contents/smt.rst
@@ -448,8 +448,8 @@ Comparing GMPEs
         strike = -999
         dip =  60 # (Albania has predominantly reverse faulting)
         rake = 90 # (+ 90 for compression, -90 for extension)
-        trellis_mag_list = [5, 6, 7] # mags used only for trellis
-        trellis_depths = [20, 20, 20] # depth per magnitude
+        trellis_mag_list = [5, 6, 7] # mags used only for trellis and response spectra
+        trellis_depths = [20, 20, 20] # depth per magnitude for trellis and response spectra
         
         # Specify magnitude array for Sammons, Euclidean dist and clustering
         [mag_values_non_trellis_functions]

--- a/openquake/smt/comparison/utils_compare_gmpes.py
+++ b/openquake/smt/comparison/utils_compare_gmpes.py
@@ -185,7 +185,7 @@ def plot_trellis_util(rake, strike, dip, depth, Z1, Z25, Vs30, region,
 
                 pyplot.loglog()
                 pyplot.ylim(0.001, 10)
-                pyplot.xlim(distances[0], distances[len(distances)-1])
+                pyplot.xlim(distances[0], distances[len(distances)-2])
                 
             pyplot.grid(axis = 'both', which = 'both', alpha = 0.5)
         

--- a/openquake/smt/comparison/utils_compare_gmpes.py
+++ b/openquake/smt/comparison/utils_compare_gmpes.py
@@ -115,9 +115,6 @@ def plot_trellis_util(rake, strike, dip, depth, Z1, Z25, Vs30, region,
                     pyplot.plot(distances, np.exp(mean), color = col,
                                 linewidth = 2, linestyle = '-', label = gmpe)
                 
-                if 'Kanno2006Shallow' in str(gmpe):
-                    print(distances)
-                
                 # Get mean +/- sigma
                 plus_sigma = np.exp(mean+Nstd*std[0])
                 minus_sigma = np.exp(mean-Nstd*std[0])

--- a/openquake/smt/comparison/utils_compare_gmpes.py
+++ b/openquake/smt/comparison/utils_compare_gmpes.py
@@ -115,6 +115,9 @@ def plot_trellis_util(rake, strike, dip, depth, Z1, Z25, Vs30, region,
                     pyplot.plot(distances, np.exp(mean), color = col,
                                 linewidth = 2, linestyle = '-', label = gmpe)
                 
+                if 'Kanno2006Shallow' in str(gmpe):
+                    print(distances)
+                
                 # Get mean +/- sigma
                 plus_sigma = np.exp(mean+Nstd*std[0])
                 minus_sigma = np.exp(mean-Nstd*std[0])

--- a/openquake/smt/comparison/utils_compare_gmpes.py
+++ b/openquake/smt/comparison/utils_compare_gmpes.py
@@ -479,9 +479,10 @@ def plot_spectra_util(rake, strike, dip, depth, Z1, Z25, Vs30, region,
                 for k, imt in enumerate(imt_list): 
                     mu, std, distances = att_curves(gmm, gmm_orig, depth[l], m,
                                                     aratio_g, strike_g, dip_g, 
-                                                    rake,Vs30, Z1, Z25, 300, 
-                                                    0.1, imt, 1, eshm20_region) 
-                    
+                                                    rake,Vs30, Z1, Z25, np.max(
+                                                    dist_list), 0.1, imt, 1,
+                                                    eshm20_region) 
+
                     mu = mu[0][0]
                     f = interpolate.interp1d(distances, mu)
                     rs_50p_dist = np.exp(f(i))

--- a/openquake/smt/comparison/utils_gmpes.py
+++ b/openquake/smt/comparison/utils_gmpes.py
@@ -145,7 +145,8 @@ def att_curves(gmpe, orig_gmpe, depth, mag, aratio, strike, dip, rake, Vs30,
     else:
         props = {'vs30': Vs30, 'z1pt0': Z1, 'z2pt5': Z25, 'backarc': False,
                  'vs30measured': True}
-                
+    
+    
     sites = get_sites_from_rupture(rup, from_point='TC', toward_azimuth=90,
                                    direction='positive', hdist=maxR, step=step,
                                    site_props=props)
@@ -160,6 +161,9 @@ def att_curves(gmpe, orig_gmpe, depth, mag, aratio, strike, dip, rake, Vs30,
     
     mean, std, tau, phi = ctxm.get_mean_stds([ctxs])
     distances = ctxs.rrup
+    
+    # Ensures can interpolate to max value in dist_list (within RS plotting)
+    distances[len(distances)-1] = maxR
     
     return mean, std, distances
 

--- a/openquake/smt/comparison/utils_gmpes.py
+++ b/openquake/smt/comparison/utils_gmpes.py
@@ -146,8 +146,10 @@ def att_curves(gmpe, orig_gmpe, depth, mag, aratio, strike, dip, rake, Vs30,
         props = {'vs30': Vs30, 'z1pt0': Z1, 'z2pt5': Z25, 'backarc': False,
                  'vs30measured': True}
                 
+    # Add 50 km to maxR to ensure can always interpolate (rrup is used for
+    # the returned distances so can be affected by rupture dip)
     sites = get_sites_from_rupture(rup, from_point='TC', toward_azimuth=90,
-                                   direction='positive', hdist=maxR, step=step,
+                                   direction='positive', hdist=maxR+50, step=step,
                                    site_props=props)
     
     mag_str = [f'{mag:.2f}']

--- a/openquake/smt/comparison/utils_gmpes.py
+++ b/openquake/smt/comparison/utils_gmpes.py
@@ -146,7 +146,6 @@ def att_curves(gmpe, orig_gmpe, depth, mag, aratio, strike, dip, rake, Vs30,
         props = {'vs30': Vs30, 'z1pt0': Z1, 'z2pt5': Z25, 'backarc': False,
                  'vs30measured': True}
     
-    
     sites = get_sites_from_rupture(rup, from_point='TC', toward_azimuth=90,
                                    direction='positive', hdist=maxR, step=step,
                                    site_props=props)

--- a/openquake/smt/comparison/utils_gmpes.py
+++ b/openquake/smt/comparison/utils_gmpes.py
@@ -146,10 +146,8 @@ def att_curves(gmpe, orig_gmpe, depth, mag, aratio, strike, dip, rake, Vs30,
         props = {'vs30': Vs30, 'z1pt0': Z1, 'z2pt5': Z25, 'backarc': False,
                  'vs30measured': True}
                 
-    # Add 50 km to maxR to ensure can always interpolate (rrup is used for
-    # the returned distances so can be affected by rupture dip)
     sites = get_sites_from_rupture(rup, from_point='TC', toward_azimuth=90,
-                                   direction='positive', hdist=maxR+50, step=step,
+                                   direction='positive', hdist=maxR, step=step,
                                    site_props=props)
     
     mag_str = [f'{mag:.2f}']

--- a/openquake/smt/tests/file_samples/example_comparison_module_inputs.toml
+++ b/openquake/smt/tests/file_samples/example_comparison_module_inputs.toml
@@ -20,8 +20,8 @@ Z25 = -999
 strike = -999
 dip =  60 # (Albania has predominantly reverse faulting)
 rake = 90 # (+ 90 for compression, -90 for extension)
-trellis_mag_list = [5, 6, 7] # mags used only for trellis
-trellis_depths = [20, 20, 20] # depth per magnitude
+trellis_mag_list = [5, 6, 7] # mags used only for trellis and response spectra
+trellis_depths = [20, 20, 20] # depth per magnitude and response spectra
 
 # Specify magnitude array for Sammons, Euclidean dist and clustering
 [mag_values_non_trellis_functions]


### PR DESCRIPTION
…han max dist_list value provided in toml (which occurs if using a shallow dipping rupture because rrup of context is used for returned distances used in interpolation for response spectra acceleration values w.r.t. distance. This fix does not modify the computed acc values but simply ensures interpolation can be performed up to maxR