### PR TITLE
fixing handling of merge log files

### DIFF
--- a/openquake/cat/hmg/merge.py
+++ b/openquake/cat/hmg/merge.py
@@ -194,9 +194,6 @@ def process_catalogues(settings_fname: str) -> None:
     # Check that the file
     if len(settings["catalogues"]) < 1:
         raise ValueError("Please specify a catalogue in the settings")
-        
-    #if "log_file" in settings["general"]:
-    #    log_fle = settings["general"]["log_file"]
 
     # Process the catalogue. `tdict` is dictionary with the info
     # required to merge one specific catalogue.
@@ -296,7 +293,6 @@ def process_catalogues(settings_fname: str) -> None:
                 logfle = tdict["log_file"]
             #
             print(f"   Log file: {logfle:s}".format())
-            print(logfle)
             # Perform the merge
             meth = catroot.add_external_idf_formatted_catalogue
             out = meth(tmpcat, delta_ll, delta_t, timezone, buff_t, buff_ll, use_kms,

--- a/openquake/cat/hmg/merge.py
+++ b/openquake/cat/hmg/merge.py
@@ -34,6 +34,7 @@ import numpy as np
 import pandas as pd
 import datetime as dt
 import geopandas as gpd
+import tempfile
 
 from openquake.cat.parsers.isf_catalogue_reader import ISFReader
 from openquake.cat.parsers.converters import GenericCataloguetoISFParser
@@ -238,7 +239,8 @@ def process_catalogues(settings_fname: str) -> None:
                 if "log_file" in settings["general"]:
                     logfle = settings["general"]["log_file"]
                 else:
-                    logfle = os.path.join(path, f"tmp_merge_{icat:02d}.tmp".format(icat))
+                    fle = tempfile.NamedTemporaryFile(mode = 'w', delete=False)
+                    logfle=fle.name
             else:
                 logfle = tdict["log_file"]
             print("   Log file: {:s}".format(logfle))
@@ -288,10 +290,13 @@ def process_catalogues(settings_fname: str) -> None:
                 if "log_file" in settings["general"]:
                     logfle = settings["general"]["log_file"]
                 else:
-                    logfle = os.path.join(path, f"tmp_merge_{icat:02d}.tmp" )
+                    fle = tempfile.NamedTemporaryFile(mode = 'w', delete=False)
+                    logfle=fle.name
+                    
+
             else:
                 logfle = tdict["log_file"]
-            #
+            
             print(f"   Log file: {logfle:s}".format())
             # Perform the merge
             meth = catroot.add_external_idf_formatted_catalogue

--- a/openquake/cat/hmg/merge.py
+++ b/openquake/cat/hmg/merge.py
@@ -194,6 +194,9 @@ def process_catalogues(settings_fname: str) -> None:
     # Check that the file
     if len(settings["catalogues"]) < 1:
         raise ValueError("Please specify a catalogue in the settings")
+        
+    #if "log_file" in settings["general"]:
+    #    log_fle = settings["general"]["log_file"]
 
     # Process the catalogue. `tdict` is dictionary with the info
     # required to merge one specific catalogue.
@@ -235,7 +238,10 @@ def process_catalogues(settings_fname: str) -> None:
 
             # Set log files
             if "log_file" not in tdict:
-                logfle = "/tmp/tmp_merge_{:02d}.tmp".format(icat)
+                if "log_file" in settings["general"]:
+                    logfle = settings["general"]["log_file"]
+                else:
+                    logfle = os.path.join(path, f"tmp_merge_{icat:02d}.tmp".format(icat))
             else:
                 logfle = tdict["log_file"]
             print("   Log file: {:s}".format(logfle))
@@ -282,11 +288,15 @@ def process_catalogues(settings_fname: str) -> None:
 
             # Set the name of the log file
             if "log_file" not in tdict:
-                logfle = f"/tmp/tmp_merge_{icat:02d}.tmp"
+                if "log_file" in settings["general"]:
+                    logfle = settings["general"]["log_file"]
+                else:
+                    logfle = os.path.join(path, f"tmp_merge_{icat:02d}.tmp" )
             else:
                 logfle = tdict["log_file"]
+            #
             print(f"   Log file: {logfle:s}".format())
-
+            print(logfle)
             # Perform the merge
             meth = catroot.add_external_idf_formatted_catalogue
             out = meth(tmpcat, delta_ll, delta_t, timezone, buff_t, buff_ll, use_kms,

--- a/openquake/cat/tests/merge_test.py
+++ b/openquake/cat/tests/merge_test.py
@@ -134,6 +134,7 @@ use_ids = false
 SETTINGS_COMCAT = """
 
 [general]
+log_file = "{:s}"
 
 [[catalogues]]
 code = "ISCGEM"
@@ -158,6 +159,7 @@ SETTINGS_GLOBAL = """
 [general]
 output_path = "{:s}"
 output_prefix = "global_"
+log_file = "{:s}"
 
 # Catalogues
 
@@ -208,6 +210,7 @@ class MergeGCMTTestCase(unittest.TestCase):
         # are escaped correctly and the resulting TOML file is valid
         td = toml.loads(SETTINGS)
         td["general"]["output_path"] = self.tmpd
+        
         td["general"]["log_file"] = os.path.join(self.tmpd, "log.txt")
         td["general"]["region_shp"] = \
             os.path.join(data_path, "shp", "test_area.shp")
@@ -216,6 +219,8 @@ class MergeGCMTTestCase(unittest.TestCase):
         td["catalogues"][1]["filename"] = \
             os.path.join(data_path, "test_gcmt.csv")
 
+        #td["catalogues"][0]["log_file"] = os.path.join(data_path, "log_isc.txt")
+        #td["catalogues"][1]["log_file"] = os.path.join(data_path, "log_gcmt.txt")
         # Create settings file
         self.settings = os.path.join(self.tmpd, "settings.toml")
         with open(self.settings, "w") as fou:
@@ -375,8 +380,7 @@ class MergeGlobalTestCase(unittest.TestCase):
         # are escaped correctly and the resulting TOML file is valid
         td = toml.loads(SETTINGS_GLOBAL)
         td["general"]["output_path"] = self.tmpd
-        print(td["catalogues"])
-        #td["general"]["log_file"] = os.path.join(self.tmpd, "log.txt")
+        td["general"]["log_file"] = os.path.join(self.tmpd, "log.txt")
         td["general"]["region_shp"] = \
             os.path.join(data_path, "shp", "test_area.shp")
         td["catalogues"][0]["filename"] = \


### PR DESCRIPTION
log files for merge were not being passed correctly to the merge function and so merge log files were created in a default location, except on windows where this didn't work.
Now log file can be specified under 'general' or with a specific catalogue in the .toml and should be passed correctly, and where no default is supplied the file will be stored in the location of the .toml file (which is now set up to work with windows file locations).