### PR TITLE
Changing /tmp/ destinations

### DIFF
--- a/openquake/ghm/grid/get_sites.py
+++ b/openquake/ghm/grid/get_sites.py
@@ -116,7 +116,8 @@ def main(model, folder_out, fname_conf, example=False):
     out_file = os.path.join(folder_out, f'{model}.geojson')
     one_polygon.columns = one_polygon.columns.astype(str)
     one_polygon.to_file(out_file, driver='GeoJSON')
-    selection.to_file('/tmp/chk.shp')
+    check_file = os.path.join(folder_out, 'check.shp')
+    selection.to_file(check_file)
 
     # Params
     h3_resolution = conf['main']['h3_resolution']


### PR DESCRIPTION
get_sites.py was putting check.shp in a /tmp file - this doesn't work on windows. 
modified output destination for check.shp to the output folder specified in the function. 