### PR TITLE
adding data store of attenuation curves

### DIFF
--- a/openquake/smt/comparison/compare_gmpes.py
+++ b/openquake/smt/comparison/compare_gmpes.py
@@ -198,34 +198,35 @@ def plot_trellis(filename, output_directory):
     # Generate config object
     config = Configurations(filename)
     
-    plot_trellis_util(config.trt,
-                      config.ztor,
-                      config.rake,
-                      config.strike,
-                      config.dip,
-                      config.trellis_and_rs_depth,
-                      config.Z1,
-                      config.Z25,
-                      config.Vs30,
-                      config.region,
-                      config.imt_list,
-                      config.trellis_and_rs_mag_list,
-                      config.minR,
-                      config.maxR,
-                      config.gmpes_list,
-                      config.aratio,
-                      config.Nstd,
-                      output_directory,
-                      config.custom_color_flag,
-                      config.custom_color_list,
-                      config.eshm20_region,
-                      config.dist_type,
-                      config.lt_weights_gmc1,
-                      config.lt_weights_gmc2,
-                      config.lt_weights_gmc3,
-                      config.lt_weights_gmc4,
-                      config.up_or_down_dip) 
-
+    store = plot_trellis_util(config.trt,
+                              config.ztor,
+                              config.rake,
+                              config.strike,
+                              config.dip,
+                              config.trellis_and_rs_depth,
+                              config.Z1,
+                              config.Z25,
+                              config.Vs30,
+                              config.region,
+                              config.imt_list,
+                              config.trellis_and_rs_mag_list,
+                              config.minR,
+                              config.maxR,
+                              config.gmpes_list,
+                              config.aratio,
+                              config.Nstd,
+                              output_directory,
+                              config.custom_color_flag,
+                              config.custom_color_list,
+                              config.eshm20_region,
+                              config.dist_type,
+                              config.lt_weights_gmc1,
+                              config.lt_weights_gmc2,
+                              config.lt_weights_gmc3,
+                              config.lt_weights_gmc4,
+                              config.up_or_down_dip) 
+    
+    return store
                 
 def plot_spectra(filename, output_directory, obs_spectra=None):
     """

--- a/openquake/smt/comparison/utils_compare_gmpes.py
+++ b/openquake/smt/comparison/utils_compare_gmpes.py
@@ -69,7 +69,7 @@ def plot_trellis_util(
             store_per_gmpe = {}
             for g, gmpe in enumerate(gmpe_list): 
                 
-                # Need another dict here
+                # Sub dicts for median, gmm sigma, median +/- Nstd * gmm sigma
                 store_per_gmpe[gmpe] = {}
                                 
                 # Perform mgmpe check

--- a/openquake/smt/demos/demo_comparison_analysis_inputs.toml
+++ b/openquake/smt/demos/demo_comparison_analysis_inputs.toml
@@ -45,43 +45,46 @@ gmpes_label = ['CA15', 'AK14', 'B20', 'L19', 'BO14', 'K1', 'K2', 'K3', 'K4', 'K5
 
 # Plot logic tree and individual GMPEs for below GMC logic tree config (gmc1)
 [models.BooreEtAl2020]
-    lt_weight_gmc1 = 0.25
+lt_weight_gmc1 = 0.25
     
 [models.LanzanoEtAl2019_RJB_OMO]
-    lt_weight_gmc1 = 0.30
+lt_weight_gmc1 = 0.30
     
 [models.BooreEtAl2014]
-    lt_weight_gmc1 = 0.15
+lt_weight_gmc1 = 0.15
 
 # Default K20_ESHM20 logic tree branches considered in gmc1
 [models.1-KothaEtAl2020ESHM20]
-    lt_weight_gmc1 = 0.000862
-    sigma_mu_epsilon = 2.85697 
-    c3_epsilon = 1.72    
+lt_weight_gmc1 = 0.000862
+sigma_mu_epsilon = 2.85697 
+c3_epsilon = 1.72    
+
 [models.2-KothaEtAl2020ESHM20]   
-    lt_weight_gmc1 = 0.067767
-    sigma_mu_epsilon = 1.35563
-    c3_epsilon = 0
+lt_weight_gmc1 = 0.067767
+sigma_mu_epsilon = 1.35563
+c3_epsilon = 0
+
 [models.3-KothaEtAl2020ESHM20]   
-    lt_weight_gmc1 = 0.162742
-    sigma_mu_epsilon = 0
-    c3_epsilon = 0        
+lt_weight_gmc1 = 0.162742
+sigma_mu_epsilon = 0
+c3_epsilon = 0        
+
 [models.4-KothaEtAl2020ESHM20]
-    lt_weight_gmc1 = 0.067767
-    sigma_mu_epsilon = -1.35563
-    c3_epsilon = 0 
+lt_weight_gmc1 = 0.067767
+sigma_mu_epsilon = -1.35563
+c3_epsilon = 0 
+
 [models.5-KothaEtAl2020ESHM20]
-    lt_weight_gmc1 = 0.000862
-    sigma_mu_epsilon = -2.85697 
-    c3_epsilon = -1.72    
-    
-    
+lt_weight_gmc1 = 0.000862
+sigma_mu_epsilon = -2.85697 
+c3_epsilon = -1.72    
+        
 # Plot logic tree only for the second GMC logic tree config (gmc2)
 [models.CauzziEtAl2014]
-    lt_weight_gmc2_plot_lt_only = 0.50
+lt_weight_gmc2_plot_lt_only = 0.50
     
 [models.AkkarEtAlRjb2014]
-    lt_weight_gmc2_plot_lt_only = 0.50
+lt_weight_gmc2_plot_lt_only = 0.50
     
 [custom_colors]
 custom_colors_flag = 'False' #(set to "True" for custom colours in plots)

--- a/openquake/smt/demos/demo_comparison_script.py
+++ b/openquake/smt/demos/demo_comparison_script.py
@@ -13,6 +13,7 @@ warnings.filterwarnings("ignore")
 # User input (can add more input tomls to run multiple analyses if required)
 file_list = ['demo_comparison_analysis_inputs.toml']
 
+attenuation_curve_data = {}
 for file in file_list:
     
     filename = file
@@ -25,8 +26,14 @@ for file in file_list:
     if not os.path.exists(output_directory): os.makedirs(output_directory)
     
     #Generate plots from config object
-    comp.plot_trellis(filename,output_directory)
+    attenuation_curve_data[file] = comp.plot_trellis(filename,output_directory)
     comp.plot_spectra(filename,output_directory)
     comp.plot_cluster(filename,output_directory)
     comp.plot_sammons(filename,output_directory)
     comp.plot_euclidean(filename,output_directory)
+    
+# The attenuation_curve_data variable stores the attenuation curves for each
+# imt-mag-depth combo per gmpe, per a config file (within which can be specified
+# additionally the eq source properties, vs30 and other params). This allows the
+# user to extract the predicted ground-motions and manipulate as they wish. Use
+# the keys of this variable to understand how the predictions are stored.


### PR DESCRIPTION
Adding datastore (in form of a dictionary) of the attenuation curves, so that the user can obtain the actual curves per gmm per mag and depth per imt with the additional params specified in the config file (e.g. vs30, number of epsilon sampled from gmm sigma), so that they can manipulate this data themselves)