### PR TITLE
[WIP] Fixing the 3D disagg plotting + adding some unit tests

### DIFF
--- a/openquake/man/tests/tools/csv_output_test.py
+++ b/openquake/man/tests/tools/csv_output_test.py
@@ -121,7 +121,7 @@ class OutputTestCase(unittest.TestCase):
             elif i == 1:
                 hea2_comp = line
             else:
-                actual_lines.append([float(j) for j in line.split()[1:]])
+                actual_lines.append([float(j) for j in line.split(',')[1:]])
 
         expected_lines = []
         for i, line in enumerate(open8(exp_mde)):
@@ -131,10 +131,9 @@ class OutputTestCase(unittest.TestCase):
                 hea2_exp = line
             if i < 2:
                 continue
-            expected_lines.append([float(j) for j in line.split()[1:]])
+            expected_lines.append([float(j) for j in line.split(',')[1:]])
 
         assert hea2_comp == hea2_exp
-
         actual_lines = np.array(actual_lines)
         expected_lines = np.array(expected_lines)
         aae = np.testing.assert_almost_equal


### PR DESCRIPTION
I think the tests were passing only because 2 empty lists were being compared (the splitting of lines without specifying a comma delimiter was producing an empty list, from which no csv values were being appended)

I will also add some unit tests for the 3D disagg plotting once I have it working on Windows 