### PR TITLE
Explain the basin term in the toml better

### DIFF
--- a/docsrc/contents/smt.rst
+++ b/docsrc/contents/smt.rst
@@ -451,7 +451,7 @@ Comparing GMPEs
         Z1 = -999
         Z25 = -999
         up_or_down_dip = 1 # 1 = up-dip, 0 = down-dip
-        region = 'Global' # get region specific z1pt0 and zpt50 ('Global' or 'Japan') 
+        z_basin_region = 'Global' # Obtain z1pt0/z2pt5 from "Global" or "JPN" (Japan) empirical Vs30-based relationships if z1pt0 or z2pt5 not specified above
         
         # Characterise earthquake for the region of interest as finite rupture
         [source_properties]

--- a/openquake/smt/comparison/compare_gmpes.py
+++ b/openquake/smt/comparison/compare_gmpes.py
@@ -60,7 +60,7 @@ class Configurations(object):
         self.Z25 = config_file['site_properties']['Z25']
         up_or_down_dip = config_file['site_properties']['up_or_down_dip']
         self.up_or_down_dip = float(up_or_down_dip)
-        self.region = config_file['site_properties']['region']
+        self.z_basin_region = config_file['site_properties']['z_basin_region']
         
         # Get rupture params
         self.trt = config_file['source_properties']['trt']

--- a/openquake/smt/comparison/utils_compare_gmpes.py
+++ b/openquake/smt/comparison/utils_compare_gmpes.py
@@ -46,7 +46,8 @@ def plot_trellis_util(config, output_directory):
     gmc_p= [[{}, {}, {}], [{}, {}, {}], [{}, {}, {}], [{}, {}, {}]]
     
     # Get basin params
-    Z1, Z25 = get_z1_z25(config.Z1, config.Z25, config.Vs30, config.region)
+    Z1, Z25 = get_z1_z25(config.Z1, config.Z25,
+                         config.Vs30, config.z_basin_region)
 
     # Get lt weights
     lt_weights = [config.lt_weights_gmc1, config.lt_weights_gmc2,
@@ -187,7 +188,8 @@ def plot_spectra_util(config, output_directory, obs_spectra):
     gmc_weights = [config.lt_weights_gmc1, config.lt_weights_gmc2,
                    config.lt_weights_gmc3, config.lt_weights_gmc4]
     imt_list, periods = _get_imts(max_period)
-    Z1, Z25 = get_z1_z25(config.Z1, config.Z25, config.Vs30, config.region)
+    Z1, Z25 = get_z1_z25(config.Z1, config.Z25,
+                         config.Vs30, config.z_basin_region)
     
     # Get colours and make the figure
     colors = get_colors(config.custom_color_flag, config.custom_color_list)     
@@ -319,7 +321,8 @@ def plot_ratios_util(config, output_directory):
     dep_list = config.trellis_and_rs_depth_list
 
     # Get basin params
-    Z1, Z25 = get_z1_z25(config.Z1, config.Z25, config.Vs30, config.region)
+    Z1, Z25 = get_z1_z25(config.Z1, config.Z25,
+                         config.Vs30, config.z_basin_region)
     
     # Get config key
     cfg_key = 'vs30 = %s m/s, GMM sigma epsilon = %s' % (config.Vs30,
@@ -409,7 +412,8 @@ def compute_matrix_gmpes(config, mtxs_type):
     
     # Set store and get z1pt0, z2pt5
     mtxs_median = {}
-    Z1, Z25 = get_z1_z25(config.Z1, config.Z25, config.Vs30, config.region)
+    Z1, Z25 = get_z1_z25(config.Z1, config.Z25,
+                         config.Vs30, config.z_basin_region)
     
     for n, i in enumerate(config.imt_list): # Iterate through imt_list
         matrix_medians=np.zeros((len(config.gmpes_list), (len(mag_list)*int((

--- a/openquake/smt/demos/demo_comparison_analysis_inputs.toml
+++ b/openquake/smt/demos/demo_comparison_analysis_inputs.toml
@@ -17,7 +17,7 @@ vs30 = 800
 Z1 = -999
 Z25 = -999
 up_or_down_dip = 1 # 1 = up-dip, 0 = down-dip
-region = 'Global' # region specific basin effects
+basin_z_region = 'Global' # Obtain z1pt0/z2pt5 from "Global" or "JPN" (Japan) empirical Vs30-based relationships if z1pt0 or z2pt5 not specified above
 
 # Characterise earthquake for the region of interest as finite rupture
 [source_properties]

--- a/openquake/smt/tests/comparison/comparison_test.py
+++ b/openquake/smt/tests/comparison/comparison_test.py
@@ -34,7 +34,7 @@ base = os.path.join(os.path.dirname(__file__), "data")
 
 # Defines the target values for each run in the inputted .toml file
 TARGET_VS30 = 800
-TARGET_REGION = 'Global'
+TARGET_Z_BASIN_REGION = 'Global'
 TARGET_TRELLIS_DEPTHS = [20, 25, 30]
 TARGET_RMIN = 0
 TARGET_RMAX = 300
@@ -90,7 +90,7 @@ class ComparisonTestCase(unittest.TestCase):
         self.assertEqual(config.Vs30, TARGET_VS30)
 
         # Check for target region
-        self.assertEqual(config.region, TARGET_REGION)
+        self.assertEqual(config.z_basin_region, TARGET_Z_BASIN_REGION)
 
         # Check for target depths (other functions use arrays from these
         # depths)

--- a/openquake/smt/tests/comparison/data/Chamoli_1999_03_28_EQ.toml
+++ b/openquake/smt/tests/comparison/data/Chamoli_1999_03_28_EQ.toml
@@ -15,8 +15,8 @@ Nstd = 1 # num. of std. dev. to sample sigma for in median prediction (0, 1, 2 o
 vs30 = 800
 Z1 = -999
 Z25 = -999
-up_or_down_dip = 0 # 1 = up-dip, 0 = down-dip
-region = 'Global' # region specific basin effects
+up_or_down_dip = 0 # 1 = up-dip, 0 = down-dist_type
+z_basin_region = 'Global' # Obtain z1pt0/z2pt5 from "Global" or "JPN" (Japan) empirical Vs30-based relationships if z1pt0 or z2pt5 not specified above
 
 # Characterise earthquake for the region of interest (note in this case we are using information in the observed spectra csv, so this information is overwritten)
 [source_properties]

--- a/openquake/smt/tests/comparison/data/compare_gmpe_inputs.toml
+++ b/openquake/smt/tests/comparison/data/compare_gmpe_inputs.toml
@@ -15,7 +15,7 @@ vs30 = 800
 Z1 = -999
 Z25 = -999
 up_or_down_dip = 1 # 1 = up-dip, 0 = down-dip
-region = 'Global' # region specific basin effects
+z_basin_region = 'Global' # Obtain z1pt0/z2pt5 from "Global" or "JPN" (Japan) empirical Vs30-based relationships if z1pt0 or z2pt5 not specified above
 
 [source_properties] # Characterise EQ as finite rupture
 trt = 'ASCR' # Either string of 'None' to use user-provided aratio OR specify a TRT string from ASCR, InSlab, Interface, Stable, Upper_Mantle, Volcanic, Induced, Induced_Geothermal to assign a trt-dependent proxy aratio

--- a/openquake/smt/tests/comparison/data/mgmpe_inputs.toml
+++ b/openquake/smt/tests/comparison/data/mgmpe_inputs.toml
@@ -14,8 +14,8 @@ Nstd = 1 # number of standard deviations to sample from sigma distribution
 vs30 = 800
 Z1 = -999
 Z25 = -999
-up_or_down_dip = 1 # 1 = up-dip, 0 = down-dip
-region = 'Global' # region specific basin effects
+up_or_down_dip = 1 # 1 = up-dip, 0 = down-dist_type
+z_basin_region = 'Global' # Obtain z1pt0/z2pt5 from "Global" or "JPN" (Japan) empirical Vs30-based relationships if z1pt0 or z2pt5 not specified above
 
 [source_properties] # Characterise EQ as finite rupture
 trt = 'ASCR' # Either string of 'None' to use user-provided aratio OR specify a TRT string from ASCR, InSlab, Interface, Stable, Upper_Mantle, Volcanic, Induced, Induced_Geothermal to assign a trt-dependent proxy aratio


### PR DESCRIPTION
It was confusing before, it now explains better that it is the region used (either global or japan) to estimate basin params (z1pt0 or z2pt5) if not specified directly by the user.