### PR TITLE
Make completeness analysis robust to a certain common failure

### DIFF
--- a/openquake/cat/completeness/analysis.py
+++ b/openquake/cat/completeness/analysis.py
@@ -328,7 +328,8 @@ def _completeness_analysis(fname, years, mags, binw, ref_mag, ref_upp_mag,
 
         # Compute occurrence
 
-        cent_mag, t_per, n_obs = get_completeness_counts(tcat, ctab, binw)
+        cent_mag, t_per, n_obs = get_completeness_counts(tcat, ctab, binw,
+                                                         return_empty=True)
         if len(cent_mag) == 0:
             continue
         wei_conf['reference_magnitude'] = min(ctab[:, 1])

--- a/openquake/fnm/inversion/utils.py
+++ b/openquake/fnm/inversion/utils.py
@@ -764,3 +764,31 @@ def get_earthquake_fault_distances(eqs, faults, dist: Optional[float] = None):
         eqs = eqs.loc[(eqs['fault_dist'] <= dist)]
 
     return eqs
+
+
+def get_on_fault_likelihood(
+    mag,
+    distance,
+    year,
+    ref_mag=6.0,
+    mag_decay_factor=1.5,
+    ref_year=2024.0,
+    time_decay_factor=0.02,
+    base_distance_decay=0.05,
+):
+
+    time_diff = ref_year - year
+
+    mag_diff = mag - ref_mag
+    if np.isscalar(mag):
+        if mag_diff < 0.0:
+            mag_diff = 0.0
+    else:
+        mag_diff[mag_diff < 0.0] = 0.0
+
+    decay_constant = base_distance_decay / (
+        1 + time_decay_factor * time_diff + mag_decay_factor * mag_diff
+    )
+    on_fault_likelihood = np.exp(-decay_constant * distance)
+
+    return on_fault_likelihood


### PR DESCRIPTION
This PR adds an argument the modified `get_completeness_counts` function in the HMTK to return empty arrays instead of breaking when there is a certain common incompatibility between a candidate completeness table and the catalog. The `_completeness_analysis` function is already set up to deal with empty arrays when a completeness table and catalog are incompatible, so now it continues without error, evaluating all the requested completeness tables.

See https://github.com/gem/oq-engine/pull/10528.