### PR TITLE
Update windows installation from 2019 to 2025

### DIFF
--- a/.github/workflows/test_win64.yaml
+++ b/.github/workflows/test_win64.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2022, windows-2019]
+        os: [windows-2022, windows-2025]
         python-version: ["3.11"]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Windows 2019 installation tests have been removed by Microsoft. We now replace with 2025 Windows installation tests as within this change for the engine by @antonioettorre - https://github.com/gem/oq-engine/commit/f04cd78059283e764950eaad0dbdba284b734c3a