### PR TITLE
change var name to match docstring in 3d disagg plotting 

### DIFF
--- a/openquake/man/tools/plot_3d_disagg.py
+++ b/openquake/man/tools/plot_3d_disagg.py
@@ -550,7 +550,7 @@ def main(dstore_fname, disagg_type, site_id=None, azimuth=-30):
     The plots can be generated for a single site by specifying the
     site_id (each site in the SiteCollection object has a site_id).
 
-    :param disagg_fname: Name of the datastore containing the calculation results.
+    :param dstore_fname: Name of the datastore containing the calculation results.
 
     :param disagg_type: Can be Mag_Dist_Eps, Mag_Lon_Lat or TRT_Lon_Lat.
 

--- a/openquake/man/tools/plot_3d_disagg.py
+++ b/openquake/man/tools/plot_3d_disagg.py
@@ -124,7 +124,7 @@ def disagg_MRE(dstore_fname, disagg_type, site_id, azimuth):
     # Get the disagg info
     ds, sites, ims, inv_t, poes, export_info, disagg_out =\
          get_info(dstore_fname, calc_id, disagg_type, site_id)
-
+    
     # Per site in the datastore
     for idx_site, site in enumerate(sites):
 
@@ -550,7 +550,7 @@ def main(dstore_fname, disagg_type, site_id=None, azimuth=-30):
     The plots can be generated for a single site by specifying the
     site_id (each site in the SiteCollection object has a site_id).
 
-    :param calc_id: Name of the datastore containing the calculation results.
+    :param disagg_fname: Name of the datastore containing the calculation results.
 
     :param disagg_type: Can be Mag_Dist_Eps, Mag_Lon_Lat or TRT_Lon_Lat.
 


### PR DESCRIPTION
dstore_fname was called calc_id in the actual list of params for 3d disagg plotting