### PR TITLE
FNM MultiFault XML fault-subfault writer

### DIFF
--- a/openquake/fnm/exporter.py
+++ b/openquake/fnm/exporter.py
@@ -55,6 +55,7 @@ from openquake.hazardlib.geo.surface.multi import (
 
 from openquake.fnm.section import get_subsection
 from openquake.fnm.fault_modeler import get_boundary_3d
+from openquake.fnm.rupture_connections import get_subfaults_on_each_fault
 
 
 def _get_profiles(kite_surf):
@@ -77,15 +78,14 @@ def make_fault_geojson_feature(fault, skip_props=('trace'), z_unit='m'):
     skip_props = ['surface', *skip_props]
     poly = get_boundary_3d(fault['surface'])[1]
 
-    feature = {'type': 'Feature',
-               'geometry': {
-                   'type': 'Polygon',
-                   'coordinates': [[list(pt) for pt in poly.exterior.coords]],
-                    },
-               'properties': {
-                   k: v for k, v in fault.items() if k not in skip_props
-                    },
-               }
+    feature = {
+        'type': 'Feature',
+        'geometry': {
+            'type': 'Polygon',
+            'coordinates': [[list(pt) for pt in poly.exterior.coords]],
+        },
+        'properties': {k: v for k, v in fault.items() if k not in skip_props},
+    }
     if z_unit == 'm':
         for c in feature['geometry']['coordinates'][0]:
             c[2] *= 1000.0
@@ -95,15 +95,17 @@ def make_fault_geojson_feature(fault, skip_props=('trace'), z_unit='m'):
 
 def make_geojson_from_faults(faults, skip_props=('trace')):
 
-    features = [make_fault_geojson_feature(fault, skip_props=skip_props)
-                for fault in faults]
+    features = [
+        make_fault_geojson_feature(fault, skip_props=skip_props)
+        for fault in faults
+    ]
 
-    gj = {"type": "FeatureCollection",
-          "features": features,
-          }
+    gj = {
+        "type": "FeatureCollection",
+        "features": features,
+    }
 
     return gj
-
 
 
 def make_multifault_source(
@@ -171,6 +173,7 @@ def make_multifault_source(
     )
 
     mfs.sections = surfaces
+    mfs.faults = get_subfaults_on_each_fault(fault_network['subfault_df'])
 
     # secparams = build_secparams(mfs.sections)
     # mfs.set_msparams(secparams)

--- a/openquake/fnm/rupture_connections.py
+++ b/openquake/fnm/rupture_connections.py
@@ -37,7 +37,7 @@ from openquake.fnm.mesh import get_mesh_bb
 from openquake.fnm.bbox import get_bb_distance
 
 # these don't work well
-#from openquake.fnm.multifault_parallel import (
+# from openquake.fnm.multifault_parallel import (
 #        find_connected_subsets_parallel,
 #        find_connected_subsets_parallel_py,
 #        )
@@ -1407,9 +1407,9 @@ def get_multifault_ruptures_fast(
         #    subgraphs, max_sf_rups_per_mf_rup
         # )
         vertex_sets = find_connected_subsets_parallel(
-            dist_adj_binary, #adj_dict,
-        #vertex_sets = find_connected_subsets_parallel_py(
-        #    adj_dict,
+            dist_adj_binary,  # adj_dict,
+            # vertex_sets = find_connected_subsets_parallel_py(
+            #    adj_dict,
             rup_groups,
             max_vertices=max_sf_rups_per_mf_rup,
         )
@@ -1616,3 +1616,13 @@ def get_multifault_rupture_distances(rupture_df, distance_matrix) -> pd.Series:
     )
 
     return distances
+
+
+def get_subfaults_on_each_fault(subfault_df: pd.DataFrame) -> Dict:
+    faults = {fid: [] for fid in subfault_df['fid'].unique()}
+    for sf_id, subfault in subfault_df.iterrows():
+        faults[subfault['fid']].append(str(sf_id))
+
+    faults = {fid: tuple(vals) for fid, vals in faults.items()}
+
+    return faults


### PR DESCRIPTION
Writes the list of subfaults on each fault in the faults.xml file when making multifault sources with Fermi, to enable disagg_by_src with multifault ruptures