### PR TITLE
removed duplicated return items in read_comp_data

### DIFF
--- a/openquake/cat/completeness/analysis.py
+++ b/openquake/cat/completeness/analysis.py
@@ -33,16 +33,20 @@ import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 
-from openquake.cat.completeness.norms import (get_norm_optimize,
-                                              get_norm_optimize_b,
-                                              get_norm_optimize_a,
-                                              get_norm_optimize_c,
-                                              get_norm_optimize_d,
-                                              get_norm_optimize_weichert,
-                                              get_norm_optimize_gft)
+from openquake.cat.completeness.norms import (
+    get_norm_optimize,
+    get_norm_optimize_b,
+    get_norm_optimize_a,
+    get_norm_optimize_c,
+    get_norm_optimize_d,
+    get_norm_optimize_weichert,
+    get_norm_optimize_gft,
+)
 from openquake.wkf.utils import _get_src_id, create_folder, get_list
-from openquake.wkf.compute_gr_params import (get_weichert_confidence_intervals,
-                                             _weichert_plot)
+from openquake.wkf.compute_gr_params import (
+    get_weichert_confidence_intervals,
+    _weichert_plot,
+)
 from openquake.mbt.tools.model_building.plt_tools import _load_catalogue
 from openquake.mbt.tools.model_building.dclustering import _add_defaults
 from openquake.hmtk.seismicity.occurrence.utils import get_completeness_counts
@@ -50,7 +54,16 @@ from openquake.hmtk.seismicity.occurrence.weichert import Weichert
 
 warnings.filterwarnings("ignore")
 
-MAXIMISE = ['optimize_a', 'optimize_b', 'optimize_c', 'optimize_d', 'optimize_weichert', 'optimize_gft', 'poisson']
+MAXIMISE = [
+    'optimize_a',
+    'optimize_b',
+    'optimize_c',
+    'optimize_d',
+    'optimize_weichert',
+    'optimize_gft',
+    'poisson',
+]
+
 
 def get_earliest_year_with_n_occurrences(ctab, cat, occ_threshold=2):
     """
@@ -160,25 +173,26 @@ def check_criterion(criterion, rate, previous_norm, tvars):
     if criterion == 'largest_rate':
 
         # Computes the rate to be maximised
-        tmp_rate = 10**(-bval * ref_mag + aval)
+        tmp_rate = 10 ** (-bval * ref_mag + aval)
         if ref_upp_mag is not None:
-            tmp_rate -= 10**(-bval * ref_upp_mag + aval)
-        norm = 1. / abs(tmp_rate)
+            tmp_rate -= 10 ** (-bval * ref_upp_mag + aval)
+        norm = 1.0 / abs(tmp_rate)
 
     elif criterion == 'match_rate':
 
         # Computes the rate to match
         rate_ma = tvars['rate_to_match']
-        tmp_rate = 10**(-bval * ref_mag + aval)
+        tmp_rate = 10 ** (-bval * ref_mag + aval)
         if ref_upp_mag is not None:
             mmax_tmp = tvars['mmax_within_range']
-            tmp_rate -= 10**(-bval * mmax_tmp + aval)
+            tmp_rate -= 10 ** (-bval * mmax_tmp + aval)
         norm = abs(tmp_rate - rate_ma)
 
     elif criterion == 'optimize':
         tmp_rate = -1
-        norm = get_norm_optimize(tcat, aval, bval, ctab, cmag, n_obs, t_per,
-                                 last_year, info=False)
+        norm = get_norm_optimize(
+            tcat, aval, bval, ctab, cmag, n_obs, t_per, last_year, info=False
+        )
 
     elif criterion == 'optimize_a':
         tmp_rate = -1
@@ -186,23 +200,36 @@ def check_criterion(criterion, rate, previous_norm, tvars):
 
     elif criterion == 'optimize_b':
         tmp_rate = -1
-        norm = get_norm_optimize_b(aval, bval, ctab, tcat, binw, ybinw=10.,
-                                   mmin=ref_mag, mmax=ref_upp_mag)
+        norm = get_norm_optimize_b(
+            aval,
+            bval,
+            ctab,
+            tcat,
+            binw,
+            ybinw=10.0,
+            mmin=ref_mag,
+            mmax=ref_upp_mag,
+        )
     elif criterion == 'optimize_c':
         tmp_rate = -1
-        norm = get_norm_optimize_c(tcat, aval, bval, ctab, last_year, ref_mag, ref_upp_mag, binw)
+        norm = get_norm_optimize_c(
+            tcat, aval, bval, ctab, last_year, ref_mag, ref_upp_mag, binw
+        )
 
     elif criterion == 'gft':
         tmp_rate = -1
-        norm = get_norm_optimize_gft(tcat, aval, bval, ctab, cmag, n_obs,
-                                     t_per, last_year)
+        norm = get_norm_optimize_gft(
+            tcat, aval, bval, ctab, cmag, n_obs, t_per, last_year
+        )
     elif criterion == 'weichert':
         tmp_rate = -1
         norm = get_norm_optimize_weichert(tcat, aval, bval, ctab, last_year)
 
     elif criterion == 'poisson':
-        tmp_rate = -1        
-        norm = get_norm_optimize_c(tcat, aval, bval, ctab, last_year, ref_mag, ref_upp_mag, binw)
+        tmp_rate = -1
+        norm = get_norm_optimize_c(
+            tcat, aval, bval, ctab, last_year, ref_mag, ref_upp_mag, binw
+        )
 
     if norm is None or np.isnan(norm):
         return False, -1, previous_norm
@@ -232,10 +259,21 @@ def _make_ctab(prm, years, mags):
         return 'skip'
 
 
-def _completeness_analysis(fname, years, mags, binw, ref_mag, ref_upp_mag,
-                           bgrlim, criterion, compl_tables, src_id=None,
-                           folder_out_figs=None, rewrite=False,
-                           folder_out=None):
+def _completeness_analysis(
+    fname,
+    years,
+    mags,
+    binw,
+    ref_mag,
+    ref_upp_mag,
+    bgrlim,
+    criterion,
+    compl_tables,
+    src_id=None,
+    folder_out_figs=None,
+    rewrite=False,
+    folder_out=None,
+):
     """
     :param fname:
         Name of the file with the catalogue
@@ -262,8 +300,18 @@ def _completeness_analysis(fname, years, mags, binw, ref_mag, ref_upp_mag,
     """
 
     # Checking input
-    if criterion not in ['match_rate', 'largest_rate', 'optimize', 'weichert',
-                         'poisson', 'optimize_a', 'optimize_b', 'optimize_c','optimize_d', 'gft']:
+    if criterion not in [
+        'match_rate',
+        'largest_rate',
+        'optimize',
+        'weichert',
+        'poisson',
+        'optimize_a',
+        'optimize_b',
+        'optimize_c',
+        'optimize_d',
+        'gft',
+    ]:
         raise ValueError('Unknown optimization criterion')
 
     tcat = _load_catalogue(fname)
@@ -281,9 +329,11 @@ def _completeness_analysis(fname, years, mags, binw, ref_mag, ref_upp_mag,
     perms = compl_tables['perms']
 
     # Configuration parameters for the Weichert method
-    wei_conf = {'magnitude_interval': binw,
-                'reference_magnitude': 0.0,
-                'bvalue': 1.0}
+    wei_conf = {
+        'magnitude_interval': binw,
+        'reference_magnitude': 0.0,
+        'bvalue': 1.0,
+    }
     weichert = Weichert()
 
     # Initial settings
@@ -327,8 +377,9 @@ def _completeness_analysis(fname, years, mags, binw, ref_mag, ref_upp_mag,
 
         if not np.any(tcat.data['magnitude'] > ctab[0][1]):
             continue
-        cent_mag, t_per, n_obs = get_completeness_counts(tcat, ctab, binw,
-                                                         return_empty=True)
+        cent_mag, t_per, n_obs = get_completeness_counts(
+            tcat, ctab, binw, return_empty=True
+        )
         if len(cent_mag) == 0:
             continue
         wei_conf['reference_magnitude'] = min(ctab[:, 1])
@@ -336,8 +387,9 @@ def _completeness_analysis(fname, years, mags, binw, ref_mag, ref_upp_mag,
         try:
             # Calculate weichert a and b parameters given the current
             # completeness
-            bval, sigb, rmag_rate, rmag_sigma_rate, aval, siga = \
-                    weichert._calculate(tcat, wei_conf, ctab)
+            bval, sigb, rmag_rate, rmag_sigma_rate, aval, siga = (
+                weichert._calculate(tcat, wei_conf, ctab)
+            )
         except:
             n_obs = [0]
             count['else'] += 1
@@ -353,7 +405,8 @@ def _completeness_analysis(fname, years, mags, binw, ref_mag, ref_upp_mag,
 
         r_mag = np.floor((ref_mag + binw * 0.01) / binw) * binw - binw / 2
         r_upp_mag = (
-            np.ceil((ref_upp_mag + binw * 0.01) / binw) * binw + binw / 2)
+            np.ceil((ref_upp_mag + binw * 0.01) / binw) * binw + binw / 2
+        )
 
         # Create a dictionary of parameters for the function that computes
         # the norm
@@ -383,7 +436,7 @@ def _completeness_analysis(fname, years, mags, binw, ref_mag, ref_upp_mag,
         # Compute the measure expressing the performance of the current
         # completeness. If the norm is smaller than the previous one
         # `check` is True
-        rates = [n/t for n,t in zip(n_obs, t_per)]
+        rates = [n / t for n, t in zip(n_obs, t_per)]
         stmags = [float(m) for m in cent_mag]
         check, trate, tnorm = check_criterion(criterion, rate, tnorm, tvars)
         all_res.append([iper, aval, bval, tnorm])
@@ -395,21 +448,44 @@ def _completeness_analysis(fname, years, mags, binw, ref_mag, ref_upp_mag,
             iper_save = iper
             rate = trate
             norm = tnorm
-            save = [aval, bval, rate, ctab, norm, siga, sigb,
-                    min(ctab[:, 1]), rmag_rate, rmag_sigma_rate]
+            save = [
+                aval,
+                bval,
+                rate,
+                ctab,
+                norm,
+                siga,
+                sigb,
+                min(ctab[:, 1]),
+                rmag_rate,
+                rmag_sigma_rate,
+            ]
             gwci = get_weichert_confidence_intervals
             lcl, ucl, ex_rates, ex_rates_scaled = gwci(
-                cent_mag, n_obs, t_per, bval)
+                cent_mag, n_obs, t_per, bval
+            )
             mmax = max(tcat.data['magnitude'])
             # Scheme:
             # 0, 1, 2, 3, 4
             # 5, 6, 7, 8, 9
             # 10, 11
             # 12, 13
-            wei = [cent_mag, n_obs, binw, t_per, ex_rates_scaled,
-                   lcl, ucl, mmax, aval, bval,
-                   wei_conf['reference_magnitude'], rmag_rate,
-                   rmag_sigma_rate, sigb]
+            wei = [
+                cent_mag,
+                n_obs,
+                binw,
+                t_per,
+                ex_rates_scaled,
+                lcl,
+                ucl,
+                mmax,
+                aval,
+                bval,
+                wei_conf['reference_magnitude'],
+                rmag_rate,
+                rmag_sigma_rate,
+                sigb,
+            ]
             count['complete'] += 1
 
     # Print info
@@ -429,10 +505,24 @@ def _completeness_analysis(fname, years, mags, binw, ref_mag, ref_upp_mag,
         return save
 
     # Plotting
-    _weichert_plot(wei[0], wei[1], wei[2], wei[3], wei[4], wei[5], wei[6],
-                   wei[7], wei[8], wei[9], src_id=src_id, plt_show=False,
-                   ref_mag=wei[10], ref_mag_rate=wei[11],
-                   ref_mag_rate_sig=wei[12], bval_sigma=wei[13])
+    _weichert_plot(
+        wei[0],
+        wei[1],
+        wei[2],
+        wei[3],
+        wei[4],
+        wei[5],
+        wei[6],
+        wei[7],
+        wei[8],
+        wei[9],
+        src_id=src_id,
+        plt_show=False,
+        ref_mag=wei[10],
+        ref_mag_rate=wei[11],
+        ref_mag_rate_sig=wei[12],
+        bval_sigma=wei[13],
+    )
 
     # Saving figure
     if folder_out_figs is not None:
@@ -441,8 +531,7 @@ def _completeness_analysis(fname, years, mags, binw, ref_mag, ref_upp_mag,
             create_folder(folder_out_figs)
         ext = 'png'
         fmt = 'fig_mfd_{:s}.{:s}'
-        figure_fname = os.path.join(folder_out_figs,
-                                    fmt.format(src_id, ext))
+        figure_fname = os.path.join(folder_out_figs, fmt.format(src_id, ext))
         plt.savefig(figure_fname, format=ext)
         plt.close()
 
@@ -458,18 +547,18 @@ def _completeness_analysis(fname, years, mags, binw, ref_mag, ref_upp_mag,
 
     return save
 
+
 def read_compl_params(config):
-    """
-    """
+    """ """
 
     # Read parameters for completeness analysis
     key = 'completeness'
     ms = np.array(config[key]['mags'], dtype=float)
     yrs = np.array(config[key]['years'])
-    try: 
-        bw = np.array(config[key]['bin_width'], dtype =float)
-    except: 
-    	bw = config.get('bin_width', 0.1)
+    try:
+        bw = np.array(config[key]['bin_width'], dtype=float)
+    except:
+        bw = config.get('bin_width', 0.1)
     r_m = config[key].get('ref_mag', 5.0)
     r_up_m = config[key].get('ref_upp_mag', None)
     bmin = config[key].get('bmin', 0.8)
@@ -481,23 +570,31 @@ def read_compl_params(config):
 
 
 def read_compl_data(folder_in):
-    """
-    """
+    """ """
     # Reading completeness data
     print(f'Reading completeness data from: {folder_in:s}')
     fname_disp = os.path.join(folder_in, 'dispositions.npy')
     perms = np.load(fname_disp)
     mags_chk = np.load(os.path.join(folder_in, 'mags.npy'))
     years_chk = np.load(os.path.join(folder_in, 'years.npy'))
-    compl_tables = {'perms': perms, 'mags_chk': mags_chk,
-                    'years_chk': years_chk}
+    compl_tables = {
+        'perms': perms,
+        'mags_chk': mags_chk,
+        'years_chk': years_chk,
+    }
 
-    return compl_tables, mags_chk, years_chk
+    return compl_tables
 
 
-
-def completeness_analysis(fname_input_pattern, f_config, folder_out_figs,
-                          folder_in, folder_out, skip='', use_only=None):
+def completeness_analysis(
+    fname_input_pattern,
+    f_config,
+    folder_out_figs,
+    folder_in,
+    folder_out,
+    skip='',
+    use_only=None,
+):
     """
     :param fname_input_pattern:
         Pattern to the files with the subcatalogues
@@ -516,14 +613,14 @@ def completeness_analysis(fname_input_pattern, f_config, folder_out_figs,
     # Loading configuration
     config = toml.load(f_config)
     ms, yrs, bw, r_m, r_up_m, bmin, bmax, crit = read_compl_params(config)
-    compl_tables, mags_chk, years_chk = read_compl_data(folder_in)
+    compl_tables = read_compl_data(folder_in)
 
     # Fixing sorting of years
     if np.all(np.diff(yrs)) >= 0:
         yrs = np.flipud(yrs)
 
-    np.testing.assert_array_almost_equal(ms, mags_chk)
-    np.testing.assert_array_almost_equal(yrs, years_chk)
+    np.testing.assert_array_almost_equal(ms, compl_tables['mags_chk'])
+    np.testing.assert_array_almost_equal(yrs, compl_tables['years_chk'])
 
     # Process input
     if len(skip) > 0:
@@ -553,12 +650,21 @@ def completeness_analysis(fname_input_pattern, f_config, folder_out_figs,
         else:
             var = {}
 
-        res = _completeness_analysis(fname, yrs, ms, bw, r_m,
-                                     r_up_m, [bmin, bmax], crit,
-                                     compl_tables, src_id,
-                                     folder_out_figs=folder_out_figs,
-                                     folder_out=folder_out,
-                                     rewrite=False)
+        res = _completeness_analysis(
+            fname,
+            yrs,
+            ms,
+            bw,
+            r_m,
+            r_up_m,
+            [bmin, bmax],
+            crit,
+            compl_tables,
+            src_id,
+            folder_out_figs=folder_out_figs,
+            folder_out=folder_out,
+            rewrite=False,
+        )
 
         if len(res) == 0:
             continue

--- a/openquake/cat/completeness/mfd_eval_plots.py
+++ b/openquake/cat/completeness/mfd_eval_plots.py
@@ -11,7 +11,9 @@ from matplotlib.patches import Ellipse
 from scipy.spatial import cKDTree
 
 
-def find_dominant_peaks(points, k=20, height_threshold=0.05, min_distance=0.2, max_peaks=5):
+def find_dominant_peaks(
+    points, k=20, height_threshold=0.05, min_distance=0.2, max_peaks=5
+):
     """
     Find a small number of dominant peaks from a 3D point cloud.
 
@@ -26,36 +28,42 @@ def find_dominant_peaks(points, k=20, height_threshold=0.05, min_distance=0.2, m
     - peaks: (M, 3) array of selected peak points (M <= max_peaks)
     """
     tree = cKDTree(points[:, :2])
-    candidate_peaks = [] 
+    candidate_peaks = []
 
     for i, pt in enumerate(points):
-        _, idxs = tree.query(pt[:2], k=k+1)
+        _, idxs = tree.query(pt[:2], k=k + 1)
         neighbors = points[idxs[1:]]  # exclude self
         # listing as a candidate peak if it's higher than the immediate neighbors
         mean_z = np.mean(neighbors[:, 2])
         if pt[2] > mean_z + height_threshold:
-            candidate_peaks.append((i, pt[2], sum(neighbors[:, 2])))  # (index, height)
+            candidate_peaks.append(
+                (i, pt[2], sum(neighbors[:, 2]))
+            )  # (index, height)
 
     # Sort candidate peaks by height descending
     candidate_peaks.sort(key=lambda x: -x[1])
     selected = []
     used_indices = set()
-    selected_buff = [] 
+    selected_buff = []
 
     for i, e, n in candidate_peaks:
         p = points[i]
         # Check if it's far enough from all already-selected peaks
-        # checking in 2d 
-        all_xy = points[:, :2] # (N, 2)
-        
-        if all(np.linalg.norm(p[:2] - all_xy[j]) >= min_distance for j in used_indices):
+        # checking in 2d
+        all_xy = points[:, :2]  # (N, 2)
+
+        if all(
+            np.linalg.norm(p[:2] - all_xy[j]) >= min_distance
+            for j in used_indices
+        ):
             selected.append(p)
             selected_buff.append(n)
             used_indices.add(i)
-            
+
             if len(selected) >= max_peaks:
                 break
     return np.array(selected), candidate_peaks, selected_buff
+
 
 def _read_results(results_dir):
     fils = glob(os.path.join(results_dir, 'full*'))
@@ -63,13 +71,13 @@ def _read_results(results_dir):
     #    avals, bvals, weis = [], [], []
     dfs = []
     for ii, fi in enumerate(fils):
-        if ii%50==0:
+        if ii % 50 == 0:
             print(f'reading instance {ii}')
         df = pd.read_csv(fi)
         idx = fi.split('_')[-1].replace('.csv', '')
         df['idx'] = [idx] * len(df)
         dfs.append(df)
-    
+
     df_all = pd.concat(dfs, ignore_index=True)
     df_all = df_all[df_all['agr'].notna()]
 
@@ -83,11 +91,11 @@ def _read_results(results_dir):
         cm_rates.append([sum(rate[ii:]) for ii in range(len(rate))])
 
     df_all['mags'] = mags
-    df_all['rates'] = rates 
+    df_all['rates'] = rates
     df_all['cm_rates'] = cm_rates
 
-
     return df_all
+
 
 def _get_best_results(df_all):
 
@@ -95,35 +103,36 @@ def _get_best_results(df_all):
     for ii, idx in enumerate(set(df_all.idx)):
         df_sub = df_all[df_all.idx == idx]
         df_subB = df_sub[df_sub.norm == min(df_sub.norm)]
-        
+
         dfs.append(df_subB)
 
     df_best = pd.concat(dfs, ignore_index=True)
 
     return df_best
 
+
 def _make_a_b_histos(df_all, df_best, figsdir):
-    fig, ax = plt.subplots(1, 2, constrained_layout=True, figsize=(10,5))
+    fig, ax = plt.subplots(1, 2, constrained_layout=True, figsize=(10, 5))
     binsA = np.arange(min(df_all.agr), max(df_all.agr), 0.1)
     binsB = np.arange(min(df_all.bgr), max(df_all.bgr), 0.02)
     num_cats = len(set(df_all.idx))
-    
+
     color = 'tab:grey'
     ax[0].set_xlabel('a-value')
     ax[0].set_ylabel('Count, all', color=color)
     ax[0].tick_params(axis='y', labelcolor=color)
-    
+
     ax[1].set_xlabel('b-value')
     ax[1].set_ylabel('Count, all', color=color)
     ax[1].tick_params(axis='y', labelcolor=color)
-    
+
     for ii, idx in enumerate(set(df_all.idx)):
 
         df_sub = df_all[df_all.idx == idx]
         if num_cats < 10:
             alpha = 0.1
-        else: 
-            alpha = 10/num_cats
+        else:
+            alpha = 10 / num_cats
 
         ax[0].hist(df_sub.agr, bins=binsA, color='gray', alpha=alpha)
         ax[1].hist(df_sub.bgr, bins=binsB, color='gray', alpha=alpha)
@@ -131,39 +140,58 @@ def _make_a_b_histos(df_all, df_best, figsdir):
     ax2b = ax[1].twinx()
     ax2a.hist(df_best.agr, bins=binsA, color='red', alpha=0.2)
     ax2b.hist(df_best.bgr, bins=binsB, color='red', alpha=0.2)
-    
+
     color = 'tab:red'
     ax2a.set_ylabel('Count, best', color=color)
     ax2a.tick_params(axis='y', labelcolor=color)
     ax2b.set_ylabel('Count, best', color=color)
     ax2b.tick_params(axis='y', labelcolor=color)
-    
+
     figname = os.path.join(figsdir, 'a-b-histos.png')
     fig.savefig(figname, dpi=300)
     plt.close(fig)
 
-def plt_compl_tables(compdir, figdir, df_best): 
-    ctabids = df_best.id.values
-    compl_tables, mags_chk, years_chk = read_compl_data(compdir)
 
-    yrs, mgs = [],[]
+def plt_compl_tables(compdir, figdir, df_best):
+    ctabids = df_best.id.values
+    compl_tables = read_compl_data(compdir)
+
+    yrs, mgs = [], []
     for cid in ctabids:
-        ctab = _make_ctab(compl_tables['perms'][int(cid)], 
-                                 years_chk, mags_chk)
+        ctab = _make_ctab(
+            compl_tables['perms'][int(cid)],
+            compl_tables['years_chk'],
+            compl_tables['mags_chk'],
+        )
 
         # add first
         plt.plot(ctab[0][0], ctab[0][1], 'ko', alpha=0.003)
-        plt.plot([ctab[0][0], ctab[0][0]+10], [ctab[0][1], ctab[0][1]], 'r--', alpha=0.003)
+        plt.plot(
+            [ctab[0][0], ctab[0][0] + 10],
+            [ctab[0][1], ctab[0][1]],
+            'r--',
+            alpha=0.003,
+        )
         yrs.append(ctab[0][0])
         mgs.append(ctab[0][1])
-    
-        for ii in range(len(ctab)-1):
-            plt.plot([ctab[ii][0], ctab[ii+1][0]], [ctab[ii+1][1], ctab[ii+1][1]], 'r', alpha=0.003)
-            plt.plot([ctab[ii][0], ctab[ii][0]], [ctab[ii][1], ctab[ii+1][1]], 'r', alpha=0.003)
-            plt.plot(ctab[ii+1][0], ctab[ii+1][1], 'ko', alpha=0.03)
-    
-            yrs.append(ctab[ii+1][0])
-            mgs.append(ctab[ii+1][1])
+
+        for ii in range(len(ctab) - 1):
+            plt.plot(
+                [ctab[ii][0], ctab[ii + 1][0]],
+                [ctab[ii + 1][1], ctab[ii + 1][1]],
+                'r',
+                alpha=0.003,
+            )
+            plt.plot(
+                [ctab[ii][0], ctab[ii][0]],
+                [ctab[ii][1], ctab[ii + 1][1]],
+                'r',
+                alpha=0.003,
+            )
+            plt.plot(ctab[ii + 1][0], ctab[ii + 1][1], 'ko', alpha=0.03)
+
+            yrs.append(ctab[ii + 1][0])
+            mgs.append(ctab[ii + 1][1])
 
     plt.title('Completeness tables: Best results/catalogue')
     plt.xlabel('Year')
@@ -178,19 +206,21 @@ def plt_compl_tables(compdir, figdir, df_best):
     plt.savefig(fout2, dpi=300)
     plt.close()
 
+
 def plt_a_b_density(df, figsdir, figname, weights=None, density=True):
-    plt.hist2d(df.agr, df.bgr, bins=(10,10), weights=weights)
+    plt.hist2d(df.agr, df.bgr, bins=(10, 10), weights=weights)
     plt.colorbar(label='Count')
     fout = os.path.join(figsdir, figname)
     plt.savefig(fout, dpi=300)
     plt.close()
 
+
 def get_top_percent(df_all, fraction):
     min_norm = min(df_all.norm)
     max_norm = max(df_all.norm)
-    thresh = abs(max_norm - min_norm) * fraction 
+    thresh = abs(max_norm - min_norm) * fraction
     df_thresh = df_all[df_all.norm <= min_norm + thresh]
-     
+
     return df_thresh
 
 
@@ -199,39 +229,74 @@ def plot_best_mfds(df_best, figsdir):
     if num <= 10:
         alpha1 = 0.1
     else:
-        alpha1 = 10/num 
+        alpha1 = 10 / num
 
     if alpha1 > 0.2:
         breakpoint()
 
     for ii in range(len(df_best)):
         row = df_best.iloc[ii]
-        mfd = TruncatedGRMFD(4, 8.5, 0.2, df_best.agr.iloc[ii], df_best.bgr.iloc[ii])
+        mfd = TruncatedGRMFD(
+            4, 8.5, 0.2, df_best.agr.iloc[ii], df_best.bgr.iloc[ii]
+        )
         mgrts = mfd.get_annual_occurrence_rates()
         mfd_m = [m[0] for m in mgrts]
         mfd_r = [m[1] for m in mgrts]
         mfd_cr = [sum(mfd_r[ii:]) for ii in range(len(mfd_r))]
         if ii == 0:
-            plt.scatter(row.mags, row.rates, marker='_', color='r', alpha=0.5*alpha1,
-                        label='Incremental occurrence')
-            plt.scatter(row.mags, row.cm_rates, marker='.', color='b', alpha=0.5*alpha1,
-                        label='Cumulative occurrence')
-            plt.semilogy(mfd_m, mfd_r, color='r', linewidth=0.3, alpha=alpha1,
-                         zorder=0, label='Incremental MFD')
-            plt.semilogy(mfd_m, mfd_cr, color='b',
-                         linewidth=0.3, zorder=0, alpha=alpha1, label='Cumulative MFD')
+            plt.scatter(
+                row.mags,
+                row.rates,
+                marker='_',
+                color='r',
+                alpha=0.5 * alpha1,
+                label='Incremental occurrence',
+            )
+            plt.scatter(
+                row.mags,
+                row.cm_rates,
+                marker='.',
+                color='b',
+                alpha=0.5 * alpha1,
+                label='Cumulative occurrence',
+            )
+            plt.semilogy(
+                mfd_m,
+                mfd_r,
+                color='r',
+                linewidth=0.3,
+                alpha=alpha1,
+                zorder=0,
+                label='Incremental MFD',
+            )
+            plt.semilogy(
+                mfd_m,
+                mfd_cr,
+                color='b',
+                linewidth=0.3,
+                zorder=0,
+                alpha=alpha1,
+                label='Cumulative MFD',
+            )
 
-        else: 
-            
+        else:
 
-            plt.scatter(row.mags, row.rates, marker='_', color='r', 
-                        alpha=0.5*alpha1)
-            plt.scatter(row.mags, row.cm_rates, marker='.', color='b', 
-                        alpha=0.5*alpha1)
-            plt.semilogy(mfd_m, mfd_r, color='r', alpha=alpha1, linewidth=0.3, 
-                         zorder=0)
-            plt.semilogy(mfd_m, mfd_cr, color='b', alpha=alpha1, 
-                         linewidth=0.3, zorder=0)
+            plt.scatter(
+                row.mags, row.rates, marker='_', color='r', alpha=0.5 * alpha1
+            )
+            plt.scatter(
+                row.mags,
+                row.cm_rates,
+                marker='.',
+                color='b',
+                alpha=0.5 * alpha1,
+            )
+            plt.semilogy(
+                mfd_m, mfd_r, color='r', alpha=alpha1, linewidth=0.3, zorder=0
+            )
+            plt.semilogy(
+                mfd_m, mfd_cr, color='b', alpha=alpha1, linewidth=0.3, zorder=0
+            )
 
     plt.xlabel('Magnitude')
     plt.ylabel('Annual occurrence rates')
@@ -243,53 +308,71 @@ def plot_best_mfds(df_best, figsdir):
     plt.savefig(fout, dpi=300)
     plt.close()
 
+
 # Function to calculate normalized histogram for a group
 def norm_histo(group, field='rates', bins=10):
     counts, bin_edges = np.histogram(group[field], bins=bins, density=True)
     # Normalize counts to ensure the area under the histogram equals 1
     bin_widths = np.diff(bin_edges)
     normalized_counts = counts * bin_widths
-    bin_centers = [0.5*(bin_edges[ii] + bin_edges[ii+1]) for ii in range(len(bin_edges)-1)]
-    alpha = (normalized_counts - min(normalized_counts)) / (max(normalized_counts) - min(normalized_counts))
+    bin_centers = [
+        0.5 * (bin_edges[ii] + bin_edges[ii + 1])
+        for ii in range(len(bin_edges) - 1)
+    ]
+    alpha = (normalized_counts - min(normalized_counts)) / (
+        max(normalized_counts) - min(normalized_counts)
+    )
 
     return bin_centers, alpha
 
+
 def weighted_mean(values, weights):
     return np.sum(values * weights) / np.sum(weights)
+
 
 def weighted_covariance(x, y, weights):
     mean_x = weighted_mean(x, weights)
     mean_y = weighted_mean(y, weights)
     cov_xy = np.sum(weights * (x - mean_x) * (y - mean_y)) / np.sum(weights)
-    cov_xx = np.sum(weights * (x - mean_x)**2) / np.sum(weights)
-    cov_yy = np.sum(weights * (y - mean_y)**2) / np.sum(weights)
+    cov_xx = np.sum(weights * (x - mean_x) ** 2) / np.sum(weights)
+    cov_yy = np.sum(weights * (y - mean_y) ** 2) / np.sum(weights)
     return np.array([[cov_xx, cov_xy], [cov_xy, cov_yy]])
 
 
-def plot_dominant_peaks(df, figdir, figname='a-b-peaks.png', 
-                        gs=15, k=7, peaks=3, dist=0.4, label=None):
+def plot_dominant_peaks(
+    df,
+    figdir,
+    figname='a-b-peaks.png',
+    gs=15,
+    k=7,
+    peaks=3,
+    dist=0.4,
+    label=None,
+):
 
     # set up data
     x = df.agr
     y = df.bgr
-    wei = 1-df.norm
-    weights = (wei - min(wei)) / (max(wei) - min(wei)) 
+    wei = 1 - df.norm
+    weights = (wei - min(wei)) / (max(wei) - min(wei))
 
     # set up plot
-    fig, ax = plt.subplots(figsize=(10,10))
+    fig, ax = plt.subplots(figsize=(10, 10))
     hb = ax.hexbin(x, y, gridsize=gs, cmap='Blues')
     cb = fig.colorbar(hb, ax=ax)
-    cb.ax.tick_params( labelsize=16)  
+    cb.ax.tick_params(labelsize=16)
     cb.set_label('counts', fontsize=20)
 
     counts = hb.get_array()
     xc = hb.get_offsets()[:, 0]
     yc = hb.get_offsets()[:, 1]
     # scale y by 10 so it scales more like x
-    points = np.stack((xc, 10*yc, counts), axis=1)
+    points = np.stack((xc, 10 * yc, counts), axis=1)
 
-    dominant, cand_peaks, sbuff = find_dominant_peaks(points, k=k, height_threshold=0.01, min_distance=dist, max_peaks=peaks)
-    plt.plot(dominant[:, 0], dominant[:, 1]/10, 'r^', ms=12, mec='w')
+    dominant, cand_peaks, sbuff = find_dominant_peaks(
+        points, k=k, height_threshold=0.01, min_distance=dist, max_peaks=peaks
+    )
+    plt.plot(dominant[:, 0], dominant[:, 1] / 10, 'r^', ms=12, mec='w')
 
     color = 'red'
     tot = sum(np.array(dominant).T[2])
@@ -298,15 +381,24 @@ def plot_dominant_peaks(df, figdir, figname='a-b-peaks.png',
     for domi in dominant:
         a1, b1, p1 = domi
         agr = np.round(a1, 3)
-        bgr = np.round(b1/10, 3)
+        bgr = np.round(b1 / 10, 3)
         p1 /= tot
         wei = np.round(p1, 3)
-        ax.text(0.02, ypo, f'a = {agr}, b = {bgr} [{wei}]',
-            transform=ax.transAxes, verticalalignment='top', horizontalalignment='left', 
-            fontsize=18, color=color)
+        ax.text(
+            0.02,
+            ypo,
+            f'a = {agr}, b = {bgr} [{wei}]',
+            transform=ax.transAxes,
+            verticalalignment='top',
+            horizontalalignment='left',
+            fontsize=18,
+            color=color,
+        )
         ypo -= 0.04
-        agrs.append(agr); bgrs.append(bgr); weights.append(wei)
-   
+        agrs.append(agr)
+        bgrs.append(bgr)
+        weights.append(wei)
+
     ax.set_xlabel('a-value', fontsize=22)
     ax.set_ylabel('b-value', fontsize=22)
     ax.set_title(figname.replace('.png', ''), fontsize=26)
@@ -320,18 +412,18 @@ def plot_dominant_peaks(df, figdir, figname='a-b-peaks.png',
     return agrs, bgrs, weights
 
 
-
-def plot_weighted_covariance_ellipse(df, figdir, n_std=1.0, gs=15,
-                                     figname='a-b-covariance.png'):
+def plot_weighted_covariance_ellipse(
+    df, figdir, n_std=1.0, gs=15, figname='a-b-covariance.png'
+):
 
     # set up data
     x = df.agr
     y = df.bgr
-    wei = 1-df.norm
-    weights = (wei - min(wei)) / (max(wei) - min(wei)) 
+    wei = 1 - df.norm
+    weights = (wei - min(wei)) / (max(wei) - min(wei))
 
     # set up plot
-    fig, ax = plt.subplots(figsize=(10,10))
+    fig, ax = plt.subplots(figsize=(10, 10))
     hb = ax.hexbin(x, y, gridsize=gs, cmap='Blues')
     cb = fig.colorbar(hb, ax=ax)
     cb.set_label('counts', fontsize=20)
@@ -339,21 +431,26 @@ def plot_weighted_covariance_ellipse(df, figdir, n_std=1.0, gs=15,
     # get covariance
     cov_matrix = weighted_covariance(x, y, weights)
     eigenvalues, eigenvectors = np.linalg.eigh(cov_matrix)
-    
+
     # Sort the eigenvalues and eigenvectors
     order = eigenvalues.argsort()[::-1]
     eigenvalues, eigenvectors = eigenvalues[order], eigenvectors[:, order]
-    
+
     # Get the index of the largest eigenvalue
     largest_eigvec = eigenvectors[:, 0]
-    
+
     angle = np.degrees(np.arctan2(largest_eigvec[1], largest_eigvec[0]))
     width, height = 2 * n_std * np.sqrt(eigenvalues)
-    
-    ellipse = Ellipse(xy=(weighted_mean(x, weights), weighted_mean(y, weights)),
-                      width=width, height=height, angle=angle,
-                      facecolor='none', edgecolor='red')
-    
+
+    ellipse = Ellipse(
+        xy=(weighted_mean(x, weights), weighted_mean(y, weights)),
+        width=width,
+        height=height,
+        angle=angle,
+        facecolor='none',
+        edgecolor='red',
+    )
+
     ax.add_patch(ellipse)
 
     angle_rad = np.radians(angle)  # angle computed during the ellipse plotting
@@ -367,26 +464,45 @@ def plot_weighted_covariance_ellipse(df, figdir, n_std=1.0, gs=15,
     # For the semi-major axis (a)
     major_x1 = center_x + a * np.cos(angle_rad)
     major_y1 = center_y + a * np.sin(angle_rad)
-    
+
     major_x2 = center_x - a * np.cos(angle_rad)
     major_y2 = center_y - a * np.sin(angle_rad)
-    
-      
+
     ax.scatter(center_x, center_y, c='white', marker='s', edgecolors='red')
     ax.scatter(major_x1, major_y1, c='white', marker='o', edgecolors='red')
     ax.scatter(major_x2, major_y2, c='white', marker='o', edgecolors='red')
 
     color = 'red'
-    ax.text(0.02, 0.98, f'a = {np.round(major_x1, 3)}, b = {np.round(major_y1, 3)}',
-            transform=ax.transAxes, verticalalignment='top', horizontalalignment='left', 
-            fontsize=12, color=color)
-    ax.text(0.02, 0.94, f'a = {np.round(center_x, 3)}, b = {np.round(center_y, 3)}',
-            transform=ax.transAxes, verticalalignment='top', horizontalalignment='left', 
-            fontsize=12, color=color)
-    ax.text(0.02, 0.90, f'a = {np.round(major_x2, 3)}, b = {np.round(major_y2, 3)}',
-            transform=ax.transAxes, verticalalignment='top', horizontalalignment='left', 
-            fontsize=12, color=color)
-    
+    ax.text(
+        0.02,
+        0.98,
+        f'a = {np.round(major_x1, 3)}, b = {np.round(major_y1, 3)}',
+        transform=ax.transAxes,
+        verticalalignment='top',
+        horizontalalignment='left',
+        fontsize=12,
+        color=color,
+    )
+    ax.text(
+        0.02,
+        0.94,
+        f'a = {np.round(center_x, 3)}, b = {np.round(center_y, 3)}',
+        transform=ax.transAxes,
+        verticalalignment='top',
+        horizontalalignment='left',
+        fontsize=12,
+        color=color,
+    )
+    ax.text(
+        0.02,
+        0.90,
+        f'a = {np.round(major_x2, 3)}, b = {np.round(major_y2, 3)}',
+        transform=ax.transAxes,
+        verticalalignment='top',
+        horizontalalignment='left',
+        fontsize=12,
+        color=color,
+    )
 
     ax.set_xlabel('a-value', fontsize=16)
     ax.set_ylabel('b-value', fontsize=16)
@@ -401,16 +517,21 @@ def plot_weighted_covariance_ellipse(df, figdir, n_std=1.0, gs=15,
     return center_x, center_y, major_x1, major_y1, major_x2, major_y2
 
 
+def plot_all_mfds(
+    df_all, df_best, figsdir, field='rates', bins=10, bw=0.2, figname=None
+):
+    # Group the DataFrame by the 'Category' column and apply the histogram calculation function
 
-def plot_all_mfds(df_all, df_best, figsdir, field='rates', bins=10, bw=0.2, figname=None):
-# Group the DataFrame by the 'Category' column and apply the histogram calculation function
-
-    fig, ax = plt.subplots(figsize=(10,6))
+    fig, ax = plt.subplots(figsize=(10, 6))
 
     fl_mags = [item for sublist in df_all.mags.values for item in sublist]
     fl_rates = [item for sublist in df_all.rates.values for item in sublist]
-    fl_crates = [item for sublist in df_all.cm_rates.values for item in sublist]
-    fl_df = pd.DataFrame({'mags': fl_mags, 'rates': fl_rates, 'cm_rates': fl_crates})
+    fl_crates = [
+        item for sublist in df_all.cm_rates.values for item in sublist
+    ]
+    fl_df = pd.DataFrame(
+        {'mags': fl_mags, 'rates': fl_rates, 'cm_rates': fl_crates}
+    )
 
     grouped = fl_df.groupby('mags')
     hist_data = grouped.apply(lambda g: norm_histo(g, field=field, bins=bins))
@@ -418,26 +539,39 @@ def plot_all_mfds(df_all, df_best, figsdir, field='rates', bins=10, bw=0.2, fign
 
     for index, row in df_best.iterrows():
         ax.scatter(row['mags'], row[field], 2, 'k', marker='s')
-        mfd = TruncatedGRMFD(min(mags)-bw, 8.5, bw, row.agr, row.bgr)
+        mfd = TruncatedGRMFD(min(mags) - bw, 8.5, bw, row.agr, row.bgr)
         mgrts = mfd.get_annual_occurrence_rates()
         mfd_m = [m[0] for m in mgrts]
         mfd_r = [m[1] for m in mgrts]
-        if len(df_best) <=30:
+        if len(df_best) <= 30:
             alpha = 0.1
-        else:  
-            alpha=30/len(df_best)
-        
+        else:
+            alpha = 30 / len(df_best)
+
         if field == 'cm_rates':
             mfd_cr = [sum(mfd_r[ii:]) for ii in range(len(mfd_r))]
-            ax.semilogy(mfd_m, mfd_cr, color='maroon', linewidth=0.2, zorder=10, alpha=alpha)
+            ax.semilogy(
+                mfd_m,
+                mfd_cr,
+                color='maroon',
+                linewidth=0.2,
+                zorder=10,
+                alpha=alpha,
+            )
         else:
-            ax.semilogy(mfd_m, mfd_r, color='maroon', linewidth=0.2, zorder=10, alpha=alpha)
+            ax.semilogy(
+                mfd_m,
+                mfd_r,
+                color='maroon',
+                linewidth=0.2,
+                zorder=10,
+                alpha=alpha,
+            )
 
-    if figname==None:
+    if figname == None:
         figname = f'mfds_all_{field}.png'
 
     fout = os.path.join(figsdir, figname)
-
 
     ax.set_xlabel('Magnitude', fontsize=16)
     ax.set_ylabel('annual occurrence rate', fontsize=16)
@@ -448,9 +582,13 @@ def plot_all_mfds(df_all, df_best, figsdir, field='rates', bins=10, bw=0.2, fign
     plt.close()
 
 
-def make_all_plots(resdir_base, compdir, figsdir_base, labels, 
-                   hist_params=[15, 7.0, 4.0, 0.4]):
-    gs = int(hist_params[0]); neighbors = int(hist_params[1]); peaks = int(hist_params[2]); dist = hist_params[3]
+def make_all_plots(
+    resdir_base, compdir, figsdir_base, labels, hist_params=[15, 7.0, 4.0, 0.4]
+):
+    gs = int(hist_params[0])
+    neighbors = int(hist_params[1])
+    peaks = int(hist_params[2])
+    dist = hist_params[3]
     agrs1, bgrs1, labs1 = [], [], []
     agrs2, bgrs2, labs2, weights2 = [], [], [], []
     for label in labels:
@@ -471,30 +609,68 @@ def make_all_plots(resdir_base, compdir, figsdir_base, labels,
         df_thresh = get_top_percent(df_all, 0.2)
         plt_a_b_density(df_thresh, figsdir, 'a-b-density_20percent.png')
         nm = df_thresh.norm
-        nm_weight = (nm- min(nm))/(max(nm)-min(nm))
-        plt_a_b_density(df_thresh, figsdir, 'a-b-density_20percent_w.png', 
-                        weights = nm_weight)
+        nm_weight = (nm - min(nm)) / (max(nm) - min(nm))
+        plt_a_b_density(
+            df_thresh,
+            figsdir,
+            'a-b-density_20percent_w.png',
+            weights=nm_weight,
+        )
         print('plotting mfds')
         plot_best_mfds(df_best, figsdir)
 
         plot_all_mfds(df_all, df_best, figsdir, field='rates', bins=60)
         plot_all_mfds(df_all, df_best, figsdir, field='cm_rates', bins=60)
-        plot_all_mfds(df_best, df_best, figsdir, field='rates', bins=60, 
-                      figname='mfds_best_rates.png')
-        plot_all_mfds(df_best, df_best, figsdir, field='cm_rates', bins=60, 
-                      figname='mfds_best_cmrates.png')
+        plot_all_mfds(
+            df_best,
+            df_best,
+            figsdir,
+            field='rates',
+            bins=60,
+            figname='mfds_best_rates.png',
+        )
+        plot_all_mfds(
+            df_best,
+            df_best,
+            figsdir,
+            field='cm_rates',
+            bins=60,
+            figname='mfds_best_cmrates.png',
+        )
         print('plotting covariance')
-        cx, cy, mx1, my1, mx2, my2 = plot_weighted_covariance_ellipse(df_best, figsdir)
-        plot_weighted_covariance_ellipse(df_thresh, figsdir, figname=f'{label}-20percent.png')
+        cx, cy, mx1, my1, mx2, my2 = plot_weighted_covariance_ellipse(
+            df_best, figsdir
+        )
+        plot_weighted_covariance_ellipse(
+            df_thresh, figsdir, figname=f'{label}-20percent.png'
+        )
 
-        a2, b2, weights = plot_dominant_peaks(df_best, figsdir, gs=gs, k=neighbors,
-                                              peaks=peaks, dist=dist, figname=label, label=label)
+        a2, b2, weights = plot_dominant_peaks(
+            df_best,
+            figsdir,
+            gs=gs,
+            k=neighbors,
+            peaks=peaks,
+            dist=dist,
+            figname=label,
+            label=label,
+        )
 
         labs1.extend([f'{label}-center', f'{label}-low', f'{label}-high'])
         agrs1.extend([cx, mx1, mx2])
         bgrs1.extend([cy, my1, my2])
 
-        labs2.extend([f'{label}-{i}' for i,w in enumerate(weights)])
-        agrs2.extend(a2); bgrs2.extend(b2); weights2.extend(weights)
+        labs2.extend([f'{label}-{i}' for i, w in enumerate(weights)])
+        agrs2.extend(a2)
+        bgrs2.extend(b2)
+        weights2.extend(weights)
 
-    return labs1, np.round(agrs1, 3), np.round(bgrs1, 3), labs2, agrs2, bgrs2, weights2
+    return (
+        labs1,
+        np.round(agrs1, 3),
+        np.round(bgrs1, 3),
+        labs2,
+        agrs2,
+        bgrs2,
+        weights2,
+    )

--- a/openquake/mbt/tools/mfd_sample/make_mfds.py
+++ b/openquake/mbt/tools/mfd_sample/make_mfds.py
@@ -15,17 +15,24 @@ from scipy.stats import truncnorm
 from copy import deepcopy
 
 from openquake.hmtk.parsers.catalogue import CsvCatalogueParser
-from openquake.mbi.ccl.decluster_multiple_TR import main as decluster_multiple_TR
+from openquake.mbi.ccl.decluster_multiple_TR import (
+    main as decluster_multiple_TR,
+)
 from openquake.cat.completeness.generate import get_completenesses
-from openquake.cat.completeness.analysis import (_completeness_analysis, 
-                                                 read_compl_params,
-                                                 read_compl_data)
+from openquake.cat.completeness.analysis import (
+    _completeness_analysis,
+    read_compl_params,
+    read_compl_data,
+)
 from openquake.cat.completeness.mfd_eval_plots import make_all_plots
-from openquake.mbi.wkf.create_subcatalogues_per_zone import create_subcatalogues
+from openquake.mbi.wkf.create_subcatalogues_per_zone import (
+    create_subcatalogues,
+)
+
 
 def _get_truncated_normal(mean=0, sd=1, low=0, upp=10):
-    return truncnorm(
-        (low - mean) / sd, (upp - mean) / sd, loc=mean, scale=sd)
+    return truncnorm((low - mean) / sd, (upp - mean) / sd, loc=mean, scale=sd)
+
 
 def _write_cat_instance(catalogue, format, fileout, cnum):
     if format == 'hmtk':
@@ -34,13 +41,15 @@ def _write_cat_instance(catalogue, format, fileout, cnum):
         with open(fileout.format(cnum), 'wb') as f:
             pickle.dump(catalogue, f)
 
-def _create_catalogue_versions(catfi, outdir, numcats=None, stype='random',
-                               numstd=1, rseed=122):
+
+def _create_catalogue_versions(
+    catfi, outdir, numcats=None, stype='random', numstd=1, rseed=122
+):
     """
     catfi: catalogue filename (pkl or hmtk/csv)
     outdir: where to put the catalogues
     numcats: number of catalogues to create, if stype is random
-    stype: 
+    stype:
         random - samples from truncnorm
         even - same sample for every magnitude; -1 : 1 by 0.2
     rseed: random seed to control the cat generation
@@ -51,7 +60,7 @@ def _create_catalogue_versions(catfi, outdir, numcats=None, stype='random',
         tmps = f'\nWarning: {outdir} already exists! '
         tmps += '\n Overwriting files.'
         print(tmps)
-   #     sys.exit(1)
+    #     sys.exit(1)
     else:
         os.makedirs(outdir)
 
@@ -61,15 +70,15 @@ def _create_catalogue_versions(catfi, outdir, numcats=None, stype='random',
         csvout = os.path.join(outdir, 'v{}_catalogue.pkl')
 
     fileout = os.path.join(outdir, 'v_mags.csv')
-    factors = np.arange(-1,1,0.1)
+    factors = np.arange(-1, 1, 0.1)
 
     # read catalogue
     if 'pkl' in catfi:
         format = 'pickle'
-        catalogue = pd.read_pickle(catfi) 
+        catalogue = pd.read_pickle(catfi)
 
     elif ('csv' in catfi) or ('hmtk' in catfi):
-        parser = CsvCatalogueParser(catfi) # From .csv to hmtk
+        parser = CsvCatalogueParser(catfi)  # From .csv to hmtk
         catalogue = parser.read_file()
         format = 'hmtk'
 
@@ -79,39 +88,44 @@ def _create_catalogue_versions(catfi, outdir, numcats=None, stype='random',
 
     data = catalogue.data
 
-    if numcats and stype == 'even': 
-        print(sys.stderr, \
-              "Cannot specify number of catalogues for even sampling.")
+    if numcats and stype == 'even':
+        print(
+            sys.stderr,
+            "Cannot specify number of catalogues for even sampling.",
+        )
         sys.exit(1)
 
-    if stype == 'random': 
+    if stype == 'random':
 
         mags = []
 
         time_strt = time.time()
-        for ii in np.arange(0,len(data['magnitude'])): 
-            m=data['magnitude'][ii]
-            sd=data['sigmaMagnitude'][ii]
-            allm = _get_truncated_normal(mean=m, sd=sd, 
-                                         low=m-numstd*sd, upp=m+numstd*sd)
+        for ii in np.arange(0, len(data['magnitude'])):
+            m = data['magnitude'][ii]
+            sd = data['sigmaMagnitude'][ii]
+            allm = _get_truncated_normal(
+                mean=m, sd=sd, low=m - numstd * sd, upp=m + numstd * sd
+            )
             mags_perm = allm.rvs(size=numcats, random_state=rseed)
             mags.append(mags_perm)
 
         marr = np.array(mags)
         np.savetxt(fileout, marr, delimiter=',', fmt='%.2f')
 
-        for ii, ms in enumerate(marr.T): 
+        for ii, ms in enumerate(marr.T):
             time_strt = time.time()
             catalogue = deepcopy(catalogue)
             catalogue.data['magnitude'] = np.array(ms)
             _write_cat_instance(catalogue, format, csvout, ii)
             time_end = time.time()
 
-
     elif stype == 'even':
         full_mags = {}
         for jj, f in enumerate(factors):
-            mags = [f * ms + m for m, ms in zip(data['magnitude'], data['sigmaMagnitude'])]
+            mags = [
+                f * ms + m
+                for m, ms in zip(data['magnitude'], data['sigmaMagnitude'])
+            ]
             catalogue = deepcopy(catalogue)
             catalogue.data['magnitude'] = np.array(mags)
             _write_cat_instance(catalogue, format, fileout, jj)
@@ -122,19 +136,20 @@ def _create_catalogue_versions(catfi, outdir, numcats=None, stype='random',
         print(sys.stderr, "Use a supported sampling type.")
         sys.exit(1)
 
-def _decl_all_cats(outdir, dcl_toml_tmp, decdir):
 
-    """
-    """
+def _decl_all_cats(outdir, dcl_toml_tmp, decdir):
+    """ """
     catvs = glob.glob(os.path.join(outdir, 'v*cat**pkl'))
     if len(catvs) == 0:
         catvs = glob.glob(os.path.join(outdir, 'v*cat*csv'))
     if len(catvs) == 0:
-        print('There are no catalogues to decluster! Check location and names.')
+        print(
+            'There are no catalogues to decluster! Check location and names.'
+        )
 
     config = toml.load(dcl_toml_tmp)
     config['main']['save_aftershocks'] = False
-    for cat in catvs: 
+    for cat in catvs:
         config['main']['catalogue'] = cat
         config['main']['output'] = decdir
         tmpfi = 'tmp-config-dcl.toml'
@@ -149,10 +164,8 @@ def _decl_all_cats(outdir, dcl_toml_tmp, decdir):
             labels.extend(config[key]['regions'])
 
 
-
 def _gen_comple(compl_toml, dec_outdir, compdir, tmpfi):
-    """
-    """
+    """ """
     config = toml.load(compl_toml)
 
     cref = config['completeness'].get('completeness_ref', None)
@@ -168,7 +181,7 @@ def _gen_comple(compl_toml, dec_outdir, compdir, tmpfi):
         mags_min = min(mags_cref) - mrange
         mags_max = max(mags_cref) + mrange
         mags_all = np.arange(mags_min, mags_max, 0.2)
-        mags = list(set([round(m,2) for m in mags_all if m >= mmin_compl ]))
+        mags = list(set([round(m, 2) for m in mags_all if m >= mmin_compl]))
         mags.sort()
         print(mags)
 
@@ -185,14 +198,12 @@ def _gen_comple(compl_toml, dec_outdir, compdir, tmpfi):
 
 
 def _compl_analysis(decdir, compdir, compl_toml, labels, fout, fout_figs):
-    """
-    """
+    """ """
     # load configs
     config = toml.load(compl_toml)
 
     ms, yrs, bw, r_m, r_up_m, bmin, bmax, crit = read_compl_params(config)
-    compl_tables, mags_chk, years_chk = read_compl_data(compdir)
-    
+    compl_tables = read_compl_data(compdir)
 
     # Fixing sorting of years
     if np.all(np.diff(yrs)) >= 0:
@@ -204,19 +215,27 @@ def _compl_analysis(decdir, compdir, compl_toml, labels, fout, fout_figs):
         fout_figs_lab = os.path.join(fout_figs, lab, 'mfds')
         for ii, cat in enumerate(dec_catvs):
             try:
-                res = _completeness_analysis(cat, yrs, ms, bw, r_m,
-                                      r_up_m, [bmin, bmax], crit,
-                                      compl_tables, f'{ii}',
-                                      folder_out_figs=fout_figs_lab,
-                                      folder_out=fout_lab,
-                                      rewrite=False)
+                res = _completeness_analysis(
+                    cat,
+                    yrs,
+                    ms,
+                    bw,
+                    r_m,
+                    r_up_m,
+                    [bmin, bmax],
+                    crit,
+                    compl_tables,
+                    f'{ii}',
+                    folder_out_figs=fout_figs_lab,
+                    folder_out=fout_lab,
+                    rewrite=False,
+                )
             except:
                 print(f'Impossible for catalogue {ii}')
 
 
 def make_many_mfds(configfile, basedir=None):
-    """
-    """
+    """ """
 
     config = toml.load(configfile)
 
@@ -224,7 +243,6 @@ def make_many_mfds(configfile, basedir=None):
     catfi = config['main']['catalogue_filename']
     outdir = config['main']['output_directory']
     labs = config['mfds'].get('labels', None)
-
 
     # make subdirs based on outdir name
     catdir = os.path.join(outdir, 'catalogues')
@@ -237,7 +255,6 @@ def make_many_mfds(configfile, basedir=None):
     figdir = os.path.join(outdir, 'figures')
     tmpconf = os.path.join(outdir, 'tmp-config-compl.toml')
 
-
     # if create_cats, make the sampled catalogues
     create_cats = config['catalogues'].get('create_catalogues', True)
     if create_cats:
@@ -245,8 +262,9 @@ def make_many_mfds(configfile, basedir=None):
         stype = config['catalogues'].get('sampling_type', 'random')
         nstd = config['catalogues'].get('num_std_devs', 1)
         rseed = config['catalogues'].get('random_seed', 122)
-        _create_catalogue_versions(catfi, catdir, numcats=ncats, stype=stype,
-                                   numstd=nstd, rseed=rseed)
+        _create_catalogue_versions(
+            catfi, catdir, numcats=ncats, stype=stype, numstd=nstd, rseed=rseed
+        )
 
     # perform all the declustering possibilities - links TRTs following configs
     decluster = config['decluster'].get('decluster_catalogues', True)
@@ -261,20 +279,22 @@ def make_many_mfds(configfile, basedir=None):
             all_cats = glob.glob(os.path.join(decdir, base))
             all_cats_cr = [c for c in all_cats if 'crustal' in c]
             for dcat in all_cats_cr:
-                verA = dcat.split('/')[-1].split('_')[0] 
-                verB = dcat.split('/')[-1].split('_')[3] 
-                subcatalogues_folder = os.path.join(outdir, "subcatalogues", f"{verA}{verB}")
+                verA = dcat.split('/')[-1].split('_')[0]
+                verB = dcat.split('/')[-1].split('_')[3]
+                subcatalogues_folder = os.path.join(
+                    outdir, "subcatalogues", f"{verA}{verB}"
+                )
                 create_subcatalogues(polys, dcat, subcatalogues_folder)
         if config.get('change_decdir', False):
             decdir = decdir.replace('declustered', 'subcatalogues/v*')
 
-    # generate the completeness tables 
+    # generate the completeness tables
     generate = config['completeness'].get('generate_completeness', True)
     if generate:
         compl_toml = config['completeness']['completeness_settings']
         _gen_comple(compl_toml, decdir, compdir, tmpconf)
 
-    # create the mfds for the given TRT labels 
+    # create the mfds for the given TRT labels
     mfds = config['mfds'].get('create_mfds', True)
     if mfds:
         if not labs:
@@ -289,18 +309,32 @@ def make_many_mfds(configfile, basedir=None):
         if not labs:
             print('Must specify the TRTs')
             sys.exit()
-        labels1, agrs1, bgrs1, labels2, agrs2, bgrs2, weights2 = make_all_plots(resdir, compdir, figdir, labs, hist_params=hist_params)
-        fin = pd.DataFrame({'label': labels1, 'a-values': agrs1, 'b-values': bgrs1})
+        labels1, agrs1, bgrs1, labels2, agrs2, bgrs2, weights2 = (
+            make_all_plots(
+                resdir, compdir, figdir, labs, hist_params=hist_params
+            )
+        )
+        fin = pd.DataFrame(
+            {'label': labels1, 'a-values': agrs1, 'b-values': bgrs1}
+        )
         if basedir:
             fin.to_csv(os.path.join(basedir, outdir, 'mfd-results-cv.csv'))
         else:
             fin.to_csv(os.path.join(outdir, 'mfd-results-cv.csv'))
 
-        fin = pd.DataFrame({'label': labels2, 'a-values': agrs2, 'b-values': bgrs2, 'weights': weights2})
+        fin = pd.DataFrame(
+            {
+                'label': labels2,
+                'a-values': agrs2,
+                'b-values': bgrs2,
+                'weights': weights2,
+            }
+        )
         if basedir:
             fin.to_csv(os.path.join(basedir, outdir, 'mfd-results-peaks.csv'))
         else:
             fin.to_csv(os.path.join(outdir, 'mfd-results-peaks.csv'))
+
 
 make_many_mfds.configfile = 'path to configuration file'
 


### PR DESCRIPTION
Ok, another little cleanup commit.

All the changes are formatting, except this change to remove the duplicated outputs (which are already in the return dicitonary), and associated changes in the few places where this code is used:

```python
def read_compl_data(folder_in):
    """
    """
    # Reading completeness data
    print(f'Reading completeness data from: {folder_in:s}')
    fname_disp = os.path.join(folder_in, 'dispositions.npy')
    perms = np.load(fname_disp)
    mags_chk = np.load(os.path.join(folder_in, 'mags.npy'))
    years_chk = np.load(os.path.join(folder_in, 'years.npy'))
    compl_tables = {'perms': perms, 'mags_chk': mags_chk,
                    'years_chk': years_chk}

    return compl_tables, mags_chk, years_chk
```

is changed to
```python
def read_compl_data(folder_in):
    """ """
    # Reading completeness data
    print(f'Reading completeness data from: {folder_in:s}')
    fname_disp = os.path.join(folder_in, 'dispositions.npy')
    perms = np.load(fname_disp)
    mags_chk = np.load(os.path.join(folder_in, 'mags.npy'))
    years_chk = np.load(os.path.join(folder_in, 'years.npy'))
    compl_tables = {
        'perms': perms,
        'mags_chk': mags_chk,
        'years_chk': years_chk,
    }

    return compl_tables
```

