### PR TITLE
Add fnm testing in CI

### DIFF
--- a/.github/workflows/test_deploy.yaml
+++ b/.github/workflows/test_deploy.yaml
@@ -58,7 +58,7 @@ jobs:
         oq --version
         sleep 3
         cd openquake
-        pytest -vsx --color=yes cat ghm man mbi mbt sub wkf smt
+        pytest -vsx --color=yes cat ghm man mbi mbt sub wkf smt fnm
   pages:
     name: pages
     runs-on: ubuntu-latest


### PR DESCRIPTION
Added 'fnm' to pytest command in test_deploy.yaml

fnm was not tested as part of the normal CI test sequence in part because of failures. These should be fixed now with updates to Fermi.