### PR TITLE
Fix: Compatibility with SciPy v1.15.3 differentiation API

### DIFF
--- a/openquake/cat/isc_homogenisor.py
+++ b/openquake/cat/isc_homogenisor.py
@@ -45,7 +45,7 @@ Origin conversion
 
 from __future__ import print_function
 import numpy as np
-from scipy.misc import derivative
+from scipy.differentiate import derivative
 from datetime import date
 from math import sqrt
 from openquake.cat.utils import _prepare_coords
@@ -202,7 +202,8 @@ class MagnitudeConversionRule(object):
         err_final = sqrt(sigma_model ** 2. + (d(model)/d(mag)) ** 2
         '''
         if self.sigma_model:
-            deriv = derivative(self.model, magnitude)
+            res = derivative(self.model, float(magnitude), preserve_shape=True)
+            deriv = res.df
             return sqrt((self.sigma_model(magnitude) ** 2.) + (deriv ** 2.) *
                         (sigma ** 2.))
         else:


### PR DESCRIPTION
This PR resolves an **ImportError** caused by the removal of _scipy.misc.derivative_ in SciPy versions 1.10 and later. The code has been updated to use new **scipy.differentiate** module, ensuring compatibility with the latest SciPy releases (v1.15+).

**Revisions:**

- Replaced the deprecated scipy.misc import with **scipy.differentiate.derivative**.
- Updated the logic to extract the derivative value using the .df attribute, as the new API returns a **RichResult** object instead of a direct float. This prevents TypeErrors during subsequent mathematical operations like _deriv 2_.
- Added explicit **float(magnitude)** casting and the **preserve_shape=True** parameter to the function call. This ensure element-wise calculations and prevents ValueErrors related to array shapes in the calculation.