### PR TITLE
Fix some edge cases in residuals

### DIFF
--- a/openquake/smt/residuals/parsers/ngawest2_flatfile_parser.py
+++ b/openquake/smt/residuals/parsers/ngawest2_flatfile_parser.py
@@ -447,13 +447,20 @@ class NGAWest2FlatfileParser(SMDatabaseReader):
                      'Mo (dyne.cm)',
                      'Station Name',
                      'Strike (deg)', 'Dip (deg)', 'Rake Angle (deg)',
-                     'EpiD (km)']
+                     'EpiD (km)',
+                     'Station Latitude', 'Station Longitude']
         for col in drop_cols:
             idx_m = ngawest2.loc[ngawest2[col] == -999].index
-            ngawest2.drop(idx_m, inplace=True)
-            ngawest2_vert.drop(idx_m, inplace=True)
-            ngawest2.reset_index(drop=True, inplace=True)
-            ngawest2_vert.reset_index(drop=True, inplace=True)
+            ngawest2 = ngawest2.drop(idx_m).reset_index(drop=True)
+            ngawest2_vert = ngawest2_vert.drop(idx_m).reset_index(drop=True)
+
+        # Drop records with non-valid rake
+        idx_rake = ngawest2.loc[
+            (ngawest2['Rake Angle (deg)'] < -180.0) |
+            (ngawest2['Rake Angle (deg)'] > 180.0)
+            ].index
+        ngawest2 = ngawest2.drop(idx_rake).reset_index(drop=True)
+        ngawest2_vert = ngawest2_vert.drop(idx_rake).reset_index(drop=True)
 
         # Replace missing year/month/day/hour/minute, cast to string first
         ngawest2['YEAR'] = ngawest2['YEAR'].astype(str)
@@ -707,7 +714,7 @@ class NGAWest2FlatfileParser(SMDatabaseReader):
 
         # Build the hdf5 files
         filename = os.path.join(location, "{:s}.hdf5".format(record.id))
-        fle = h5py.File(filename, "w-")
+        fle = h5py.File(filename, "w")
         ims_grp = fle.create_group("IMS")
         for comp, key in [("X", "U"), ("Y", "V"), ("V", "W")]:
             comp_grp = ims_grp.create_group(comp)

--- a/openquake/smt/residuals/parsers/ngawest2_flatfile_parser.py
+++ b/openquake/smt/residuals/parsers/ngawest2_flatfile_parser.py
@@ -714,7 +714,7 @@ class NGAWest2FlatfileParser(SMDatabaseReader):
 
         # Build the hdf5 files
         filename = os.path.join(location, "{:s}.hdf5".format(record.id))
-        fle = h5py.File(filename, "w")
+        fle = h5py.File(filename, "w-")
         ims_grp = fle.create_group("IMS")
         for comp, key in [("X", "U"), ("Y", "V"), ("V", "W")]:
             comp_grp = ims_grp.create_group(comp)

--- a/openquake/smt/residuals/sm_database.py
+++ b/openquake/smt/residuals/sm_database.py
@@ -29,6 +29,7 @@ from openquake.hazardlib.site import Site, SiteCollection
 from openquake.hazardlib.geo.point import Point
 from openquake.hazardlib.geo import geodetic
 from openquake.hazardlib.contexts import ContextMaker
+from openquake.hazardlib.calc.filters import magdepdist
 from openquake.hazardlib.const import TRT
 
 from openquake.smt import utils
@@ -877,7 +878,11 @@ class GroundMotionDatabase(ContextDB):
         
         # Make the ctx for given station which contains all distances
         mag_str = [f'{rup.mag:.2f}']
-        oqp = {'imtls': {"PGA": []}, 'mags': mag_str}
+        oqp = {'imtls': {"PGA": []}, 'mags': mag_str,
+               # Use large max dist to avoid filtering out very
+               # far away sites within genctx (in the ctx maker)
+               'maximum_distance': magdepdist(
+                   [(2.5, 20000.), (10.2, 20000.)])}
         ctxm = ContextMaker(
             rup.tectonic_region_type, [utils.full_dtype_gmm()], oqp)
         ctxs = ctxm.get_ctxs([rup], site)


### PR DESCRIPTION
Add a large max hazard integration distance to oqparam when creating ctx in residuals to avoid very far away stations being silently filtered out and therefore generating an empty ctx list silently (raising a very ambiguous indexing error).

Add some more filters to the NGAWest2 to avoid erroneous metadata issues (e.g. rakes reported by NGAWest2 outside of -180 to 180).