### PR TITLE
extent dtype in classifierm to avoid numpy2 hard error + fix CRS issue on remote test for ghm

### DIFF
--- a/openquake/ghm/create_buffers.py
+++ b/openquake/ghm/create_buffers.py
@@ -420,7 +420,7 @@ def main(fname_config):
     # Save buffer to folder
     print(f"Saving file")
     tmpgdf = tmpgdf.set_crs("EPSG:4326")
-    tmpgdf.to_file(out_fname, driver='GeoJSON')
+    tmpgdf.to_file(out_fname, driver='GeoJSON', engine='fiona')
     print(f"Created file: {out_fname} with {len(tmpgdf)} buffers")
     print(f"\nStart time: {datetime.datetime.now()} [s]")
 

--- a/openquake/ghm/tests/create_buffers_test.py
+++ b/openquake/ghm/tests/create_buffers_test.py
@@ -28,6 +28,12 @@
 Module create_buffer_test
 """
 import os
+
+# Force pyogrio's GDAL to use its bundled proj.db (the OQ venv's PROJ_LIB
+# points at a schema-incompatible version on teh Linux CI)
+os.environ.pop("PROJ_LIB", None)
+os.environ.pop("PROJ_DATA", None)
+
 import toml
 import pathlib
 import tempfile
@@ -38,11 +44,6 @@ import geopandas as gpd
 from openquake.ghm.create_buffers import main
 
 HERE = pathlib.Path(__file__).parent.resolve()
-
-# Force pyogrio's GDAL to use its bundled proj.db (the OQ venv's PROJ_LIB
-# points at a schema-incompatible version on teh Linux CI).
-os.environ.pop("PROJ_LIB", None)
-os.environ.pop("PROJ_DATA", None)
 
 
 

--- a/openquake/ghm/tests/create_buffers_test.py
+++ b/openquake/ghm/tests/create_buffers_test.py
@@ -27,7 +27,7 @@
 """
 Module create_buffer_test
 """
-
+import os
 import toml
 import pathlib
 import tempfile
@@ -38,6 +38,12 @@ import geopandas as gpd
 from openquake.ghm.create_buffers import main
 
 HERE = pathlib.Path(__file__).parent.resolve()
+
+# Force pyogrio's GDAL to use its bundled proj.db (the OQ venv's PROJ_LIB
+# points at a schema-incompatible version on teh Linux CI).
+os.environ.pop("PROJ_LIB", None)
+os.environ.pop("PROJ_DATA", None)
+
 
 
 class BufferCreateTestCase(unittest.TestCase):

--- a/openquake/ghm/tests/create_buffers_test.py
+++ b/openquake/ghm/tests/create_buffers_test.py
@@ -27,6 +27,7 @@
 """
 Module create_buffer_test
 """
+
 import toml
 import pathlib
 import tempfile
@@ -37,7 +38,6 @@ import geopandas as gpd
 from openquake.ghm.create_buffers import main
 
 HERE = pathlib.Path(__file__).parent.resolve()
-
 
 
 class BufferCreateTestCase(unittest.TestCase):

--- a/openquake/ghm/tests/create_buffers_test.py
+++ b/openquake/ghm/tests/create_buffers_test.py
@@ -27,13 +27,6 @@
 """
 Module create_buffer_test
 """
-import os
-
-# Force pyogrio's GDAL to use its bundled proj.db (the OQ venv's PROJ_LIB
-# points at a schema-incompatible version on teh Linux CI)
-os.environ.pop("PROJ_LIB", None)
-os.environ.pop("PROJ_DATA", None)
-
 import toml
 import pathlib
 import tempfile

--- a/openquake/mbt/tools/tr/set_crustal_earthquakes.py
+++ b/openquake/mbt/tools/tr/set_crustal_earthquakes.py
@@ -96,11 +96,12 @@ class SetCrustalEarthquakes():
             # final TR
             treg = np.logical_and(treg, isel)
 
+        str_dt = h5py.string_dtype(encoding='utf-8')
         tl = np.zeros(len(treg),
-                      dtype={'names': ('eid', 'lon', 'lat', 'dep', 'moh', 'idx'),
-                             'formats': ('U64', 'f8', 'f8', 'f8', 'f8', 'i4')})
+                      dtype=[('eid', str_dt), ('lon', 'f8'), ('lat', 'f8'),
+                             ('dep', 'f8'), ('moh', 'f8'), ('idx', 'i4')])
 
-        tl['eid'] = icat.data['eventID']
+        tl['eid'] = [str(s) for s in icat.data['eventID']]
         tl['lon'] = icat.data['longitude']
         tl['lat'] = icat.data['latitude']
         tl['dep'] = icat.data['depth']

--- a/openquake/mbt/tools/tr/set_crustal_earthquakes.py
+++ b/openquake/mbt/tools/tr/set_crustal_earthquakes.py
@@ -98,7 +98,7 @@ class SetCrustalEarthquakes():
 
         tl = np.zeros(len(treg),
                       dtype={'names': ('eid', 'lon', 'lat', 'dep', 'moh', 'idx'),
-                             'formats': ('S15', 'f8', 'f8', 'f8', 'f8', 'i4')})
+                             'formats': ('U64', 'f8', 'f8', 'f8', 'f8', 'i4')})
 
         tl['eid'] = icat.data['eventID']
         tl['lon'] = icat.data['longitude']

--- a/openquake/mbt/tools/tr/set_subduction_earthquakes.py
+++ b/openquake/mbt/tools/tr/set_subduction_earthquakes.py
@@ -334,12 +334,12 @@ class SetSubductionEarthquakes:
         self.treg = treg
 
         # Store log data
+        str_dt = h5py.string_dtype(encoding='utf-8')
         tl = np.zeros(len(idxa),
-                      dtype={'names': ('eid', 'lon', 'lat', 'dep', 'subd',
-                                       'srfd', 'idx'),
-                             'formats': ('U64', 'f8', 'f8', 'f8', 'f8', 'f8',
-                                         'i4')})
-        tl['eid'] = cat.data['eventID']
+                      dtype=[('eid', str_dt), ('lon', 'f8'), ('lat', 'f8'),
+                             ('dep', 'f8'), ('subd', 'f8'), ('srfd', 'f8'),
+                             ('idx', 'i4')])
+        tl['eid'] = [str(s) for s in cat.data['eventID']]
         tl['lon'] = cat.data['longitude']
         tl['lat'] = cat.data['latitude']
         tl['dep'] = cat.data['depth']

--- a/openquake/mbt/tools/tr/set_subduction_earthquakes.py
+++ b/openquake/mbt/tools/tr/set_subduction_earthquakes.py
@@ -337,7 +337,7 @@ class SetSubductionEarthquakes:
         tl = np.zeros(len(idxa),
                       dtype={'names': ('eid', 'lon', 'lat', 'dep', 'subd',
                                        'srfd', 'idx'),
-                             'formats': ('S15', 'f8', 'f8', 'f8', 'f8', 'f8',
+                             'formats': ('U64', 'f8', 'f8', 'f8', 'f8', 'f8',
                                          'i4')})
         tl['eid'] = cat.data['eventID']
         tl['lon'] = cat.data['longitude']


### PR DESCRIPTION

Fix ghm test that only fails on remote of:

`FAILED ghm/tests/create_buffers_test.py::BufferCreateTestCase::test_simple_test - pyogrio.errors.CRSError: Could not set CRS: EPSG:4326`

The easiest fix I think is to specify fiona as the writer instead of pyogrio when writing the buffer to file - it has same output as before but fiona's GDAL is compatible with the proj.db available on the CI so the coord ref system lookup succeeds on remote again now as well (and still on local like before)

-----------------------------

Switched eid in `set_subduction_earthquakes.py` and `set_crustal_earthquakes.py` to h5py vlen UTF-8 because existing S15 limit prevents using the long native NGAWest3 event IDs in flatfile homogenisation workflow.

NB: Previously a truncation to 15 characters was performed silently, but it seems in numpy 2.x that a hard error is raised, hence the issue arising now I think.

NB: In my internal classification workflow I could probably truncate to shorter (still unique) event IDs and then map back, but I think 15 characters could be relaxed anyway.
