### PR TITLE
Adding utils for simple SES generation

### DIFF
--- a/openquake/man/ses_utils/ses_cat.py
+++ b/openquake/man/ses_utils/ses_cat.py
@@ -29,8 +29,8 @@
 # coding: utf-8
 
 """
-module :mod:`openquake.man.ses_cat` provides functions to build an HMTK-formatted 
-catalogue from OpenQuake SES event/rupture outputs.
+module :mod:`openquake.man.ses_utils.ses_cat` provides functions to build an 
+HMTK-formatted catalogue from OpenQuake SES event/rupture outputs.
 """
 
 import os
@@ -52,7 +52,6 @@ def merge_ses_event_rupture(event_file: str, rupture_file: str) -> pd.DataFrame:
     events = pd.read_csv(event_file, comment='#', sep=None, engine='python')
     ruptures = pd.read_csv(rupture_file, comment='#', sep=None, engine='python')
     return events.merge(ruptures, on="rup_id", how="left")
-
 
 def add_random_datetime(df: pd.DataFrame, seed: int = 42) -> pd.DataFrame:
     """
@@ -93,7 +92,6 @@ def add_random_datetime(df: pd.DataFrame, seed: int = 42) -> pd.DataFrame:
     df["Date"] = df.apply(lambda r: f"{int(r['month']):02d}/{int(r['day']):02d}/{int(r['year']):04d}", axis=1)
     return df
 
-
 def convert_to_hmtk(df: pd.DataFrame) -> pd.DataFrame:
     """
     Converting SES merged catalogue to HMTK-compatible column names.
@@ -123,7 +121,6 @@ def convert_to_hmtk(df: pd.DataFrame) -> pd.DataFrame:
 
     return df.reindex(columns=cols)
 
-
 def build_hmtk_ses_catalogue(event_file: str,
                              rupture_file: str,
                              output_file: str,
@@ -152,4 +149,3 @@ def build_hmtk_ses_catalogue(event_file: str,
     df.to_csv(output_file, index=False)
 
     return output_file
-

--- a/openquake/man/ses_utils/ses_generator.py
+++ b/openquake/man/ses_utils/ses_generator.py
@@ -1,0 +1,61 @@
+# ------------------- The OpenQuake Model Building Toolkit --------------------
+# Copyright (C) 2026 GEM Foundation and Électricité de France
+#           _______  _______        __   __  _______  _______  ___   _
+#          |       ||       |      |  |_|  ||  _    ||       ||   | | |
+#          |   _   ||   _   | ____ |       || |_|   ||_     _||   |_| |
+#          |  | |  ||  | |  ||____||       ||       |  |   |  |      _|
+#          |  |_|  ||  |_|  |      |       ||  _   |   |   |  |     |_
+#          |       ||      |       | ||_|| || |_|   |  |   |  |    _  |
+#          |_______||____||_|      |_|   |_||_______|  |___|  |___| |_|
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This script is produced within the scope of Work Package 5, named Simulation 
+# platform, under SIGMA3 project. For more detailed information about 
+# the project, please visit to https://sigma-programs.com/.
+# -----------------------------------------------------------------------------
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+# coding: utf-8
+
+"""
+module :mod:`openquake.man.ses_utils.ses_generator` provides a function to 
+generate 1000 years Stochastic Event Sets (SES) by sampling earthquake ruptures 
+from configured seismic sources using Monte Carlo sampling.
+"""
+
+from openquake.man.ses_utils.ses_source import get_area_source
+
+
+def ses_from_area_source(fname: str, mfd, hdd=None):
+    """
+    Generates a stochastic event set from an Area Source
+
+    :param fname:
+        A string with the name of the file with the geometry of
+        the area source. It can be of any format (e.g. shapefile, 
+        geojson, geopackage).
+    :param mfd:
+        An instance of a concrete class of 
+        :class:`openquake.hazardlib.mfd.base.BaseMFD`
+    :param hdd:
+        An instance of :class:`openquake.hazardlib.pmf.PMF` instance 
+        describing the hypocentral depth distribution. For example:
+        pmf = PMF([(0.3, 5.0), (0.7, 10.0)])
+    """
+    src = get_area_source(mfd, polygon_fname=fname, hdd=hdd)
+    src.smweight = 1.0
+    rups = []
+    rups.extend(src.sample_ruptures(1000, 0))
+
+    return rups

--- a/openquake/man/ses_utils/ses_generator.py
+++ b/openquake/man/ses_utils/ses_generator.py
@@ -30,34 +30,51 @@
 
 """
 module :mod:`openquake.man.ses_utils.ses_generator` provides a function to 
-generate 1000 years Stochastic Event Sets (SES) by sampling earthquake ruptures 
+simulate 1000 Stochastic Event Set (SES) by sampling earthquake ruptures 
 from configured seismic sources using Monte Carlo sampling.
 """
+
+import numpy as np
 
 from openquake.man.ses_utils.ses_source import get_area_source
 
 
+def prepare_source_for_sampling(src):
+    """
+    Prepares a source for rupture sampling.
+
+    It assigns the minimum metadata normally initialized by the
+    OpenQuake Engine so that ``sample_ruptures()`` can be called directly
+    on a source created through hazardlib.
+
+    :param src:
+        An OpenQuake seismic source.
+    :returns:
+        The prepared source with the required sampling metadata.
+    """
+    src.id = 0
+    src.offset = 0
+    src.smweight = 1.0
+    src.sampling = {
+        'samples': np.array([1], dtype=np.uint32),
+        'trt_smr': np.array([0], dtype=np.uint32),
+    }
+    return src
+
 def ses_from_area_source(fname: str, mfd, hdd=None):
     """
-    Generates a stochastic event set from an Area Source
+    Generates a stochastic event set from an Area Source.
 
     :param fname:
-        A string with the name of the file with the geometry of
-        the area source. It can be of any format (e.g. shapefile, 
-        geojson, geopackage).
+        Path to the GeoJSON file containing the area-source geometry.
     :param mfd:
-        An instance of a concrete class of 
-        :class:`openquake.hazardlib.mfd.base.BaseMFD`
+        An OpenQuake magnitude-frequency distribution instance.
     :param hdd:
-        An instance of :class:`openquake.hazardlib.pmf.PMF` instance 
-        describing the hypocentral depth distribution. For example:
-        pmf = PMF([(0.3, 5.0), (0.7, 10.0)])
+        Optional hypocentral-depth probability mass function.
+    :returns:
+        A list of :class:`~openquake.hazardlib.source.rupture.EBRupture`
+        objects representing the simulated stochastic event set.
     """
     src = get_area_source(mfd, polygon_fname=fname, hdd=hdd)
-    src.smweight = 1.0
-    rups = []
-    result = src.sample_ruptures(1000, 0)
-    if result is not None:
-        rups.extend(result)
-
-    return rups
+    prepare_source_for_sampling(src)
+    return src.sample_ruptures(num_ses=1000, ses_seed=0)

--- a/openquake/man/ses_utils/ses_generator.py
+++ b/openquake/man/ses_utils/ses_generator.py
@@ -56,6 +56,8 @@ def ses_from_area_source(fname: str, mfd, hdd=None):
     src = get_area_source(mfd, polygon_fname=fname, hdd=hdd)
     src.smweight = 1.0
     rups = []
-    rups.extend(src.sample_ruptures(1000, 0))
+    result = src.sample_ruptures(1000, 0)
+    if result is not None:
+        rups.extend(result)
 
     return rups

--- a/openquake/man/ses_utils/ses_generator.py
+++ b/openquake/man/ses_utils/ses_generator.py
@@ -36,10 +36,10 @@ from configured seismic sources using Monte Carlo sampling.
 
 import numpy as np
 
-from openquake.man.ses_utils.ses_source import get_area_source
+from openquake.man.ses_utils.ses_source import make_area_source
 
 
-def prepare_source_for_sampling(src):
+def prepare_source_for_sampling(src, samples=1):
     """
     Prepares a source for rupture sampling.
 
@@ -49,6 +49,8 @@ def prepare_source_for_sampling(src):
 
     :param src:
         An OpenQuake seismic source.
+    :param samples:
+        Number of source-model samples associated with the source. Default is 1.
     :returns:
         The prepared source with the required sampling metadata.
     """
@@ -56,12 +58,12 @@ def prepare_source_for_sampling(src):
     src.offset = 0
     src.smweight = 1.0
     src.sampling = {
-        'samples': np.array([1], dtype=np.uint32),
+        'samples': np.array([samples], dtype=np.uint32),
         'trt_smr': np.array([0], dtype=np.uint32),
     }
     return src
 
-def ses_from_area_source(fname: str, mfd, hdd=None):
+def ses_from_area_source(fname: str, mfd, hdd=None, num_ses=1000, ses_seed=0, samples=1):
     """
     Generates a stochastic event set from an Area Source.
 
@@ -71,10 +73,16 @@ def ses_from_area_source(fname: str, mfd, hdd=None):
         An OpenQuake magnitude-frequency distribution instance.
     :param hdd:
         Optional hypocentral-depth probability mass function.
+    :param num_ses:
+        Number of stochastic event sets to simulate.
+    :param ses_seed:
+        Seed used for stochastic rupture sampling.
+    :param samples:
+        Number of source-model samples associated with the source.
     :returns:
         A list of :class:`~openquake.hazardlib.source.rupture.EBRupture`
         objects representing the simulated stochastic event set.
     """
-    src = get_area_source(mfd, polygon_fname=fname, hdd=hdd)
-    prepare_source_for_sampling(src)
-    return src.sample_ruptures(num_ses=1000, ses_seed=0)
+    src = make_area_source(mfd, polygon_fname=fname, hdd=hdd)
+    prepare_source_for_sampling(src, samples=samples)
+    return src.sample_ruptures(num_ses=num_ses, ses_seed=ses_seed)

--- a/openquake/man/ses_utils/ses_geo.py
+++ b/openquake/man/ses_utils/ses_geo.py
@@ -1,0 +1,60 @@
+# ------------------- The OpenQuake Model Building Toolkit --------------------
+# Copyright (C) 2026 GEM Foundation and Électricité de France
+#           _______  _______        __   __  _______  _______  ___   _
+#          |       ||       |      |  |_|  ||  _    ||       ||   | | |
+#          |   _   ||   _   | ____ |       || |_|   ||_     _||   |_| |
+#          |  | |  ||  | |  ||____||       ||       |  |   |  |      _|
+#          |  |_|  ||  |_|  |      |       ||  _   |   |   |  |     |_
+#          |       ||      |       | ||_|| || |_|   |  |   |  |    _  |
+#          |_______||____||_|      |_|   |_||_______|  |___|  |___| |_|
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This script is produced within the scope of Work Package 5, named Simulation 
+# platform, under SIGMA3 project. For more detailed information about 
+# the project, please visit to https://sigma-programs.com/.
+# -----------------------------------------------------------------------------
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+# coding: utf-8
+
+"""
+module :mod:`openquake.man.ses_utils.ses_geo` provides a function for 
+parsing geospatial data files (e.g., GeoJSON, Shapefile) and converting 
+their geometries into OQ Engine polygon instances.
+"""
+
+import pathlib
+import numpy as np
+import geopandas as gpd
+
+from openquake.hazardlib.geo import Polygon, Point
+
+def get_oq_polygons(fname: str):
+    """
+    Returns a list of OQ Engine Polygon :class:`openquake.hazardlib.geo.Polygon`
+    instances
+
+    :param fname:
+        The name of a shapefile or a geojson containing one polygon
+    """
+
+    if not pathlib.Path(fname).exists():
+        raise IOError(f'File {fname} does not exists')
+
+    gdf = gpd.read_file(fname)
+    polys = []
+    for i_row, row in gdf.iterrows():
+        coo = np.array([c for c in row.geometry.exterior.coords])
+        polys.append(Polygon([Point(p[0], p[1]) for p in coo]))
+    return polys

--- a/openquake/man/ses_utils/ses_geo.py
+++ b/openquake/man/ses_utils/ses_geo.py
@@ -55,6 +55,13 @@ def get_oq_polygons(fname: str):
     gdf = gpd.read_file(fname)
     polys = []
     for i_row, row in gdf.iterrows():
+        if row.geometry is None or row.geometry.exterior is None:
+            continue
+        
         coo = np.array([c for c in row.geometry.exterior.coords])
         polys.append(Polygon([Point(p[0], p[1]) for p in coo]))
+
+    if len(polys) == 0:
+        raise ValueError('The file does not contain any valid polygons')
+    
     return polys

--- a/openquake/man/ses_utils/ses_source.py
+++ b/openquake/man/ses_utils/ses_source.py
@@ -43,35 +43,54 @@ from openquake.hazardlib.scalerel import get_available_area_scalerel
 from openquake.man.ses_utils.ses_geo import get_oq_polygons
 
 
-def get_area_source(
+def make_area_source(
             mfd,
             polygon_fname,
             hdd=None,
-            grid_spacing=10.
+            npd=None,
+            grid_spacing=10.,
+            msr='WC1994',
+            upper_seismogenic_depth=0.0,
+            lower_seismogenic_depth=15.0
         ):
     """
-    Returns an OQ Engine area source instance
+    Creates an OQ Engine AreaSource from a polygon geometry and
+    the provided source parameters.
 
     :param mfd:
         An instance of OQ Engine magnitude-frequency distribution class
     :param polygon_fname:
-        An instance of a OQ Engine polygon class. See :class:`openquake.hazardlib.geo.Polygon`
+        Path to file containing polygon geometry of area source (e.g. GeoJSON or shapefile).
     :param hdd:
-        An instance of a PMF class. See  :class:`openquake.hazardlib.pmf.PMF`
+        An optional :class:`openquake.hazardlib.pmf.PMF` describing the hypocentral depth distribution.
+        If not provided, a single hypocentral depth of 7.5 km is used.
+    :param npd:
+        An optional :class:`openquake.hazardlib.pmf.PMF` describing the nodal plane distribution. 
+        If not provided, a single nodal plane with strike=0, dip=90, and rake=0 is used.
     :param grid_spacing:
         Grid spacing used for area source discretization.
+    :param msr:
+        Name of the magnitude scaling relationship to use. Default is ``'WC1994'``.
+    :param upper_seismogenic_depth:
+        Upper seismogenic depth in km. Default is 0.0.
+    :param lower_seismogenic_depth:
+        Lower seismogenic depth in km. Default is 15.0.
+    :returns:
+        An :class:`openquake.hazardlib.source.AreaSource` instance created
+        from the provided geometry and source parameters.
     """
 
     # Magnitude scaling-relationship
     msrs = get_available_area_scalerel()
-    msr = msrs['WC1994']()
+    msr = msrs[msr]()
 
     # Temporal occurrence model
     time_span = 1.0
     tom = PoissonTOM(time_span)
 
     # Nodal plane distribution
-    npd = PMF([(1.0, NodalPlane(0.0, 90.0, 0.0))])
+    if npd is None:
+        npd = PMF([(1.0, NodalPlane(0.0, 90.0, 0.0))])
 
     # Upper and lower seismogenic depth
     usd = 0
@@ -80,8 +99,8 @@ def get_area_source(
     if hdd is None:
         hdd = PMF([(1.0, 7.5)])
     else:
-        usd = np.min([v[1] for v in hdd.data])
-        lsd = np.max([v[1] for v in hdd.data])
+        usd = upper_seismogenic_depth
+        lsd = lower_seismogenic_depth
 
     # Get geometry
     polys = get_oq_polygons(polygon_fname)

--- a/openquake/man/ses_utils/ses_source.py
+++ b/openquake/man/ses_utils/ses_source.py
@@ -1,0 +1,111 @@
+# ------------------- The OpenQuake Model Building Toolkit --------------------
+# Copyright (C) 2026 GEM Foundation and Électricité de France
+#           _______  _______        __   __  _______  _______  ___   _
+#          |       ||       |      |  |_|  ||  _    ||       ||   | | |
+#          |   _   ||   _   | ____ |       || |_|   ||_     _||   |_| |
+#          |  | |  ||  | |  ||____||       ||       |  |   |  |      _|
+#          |  |_|  ||  |_|  |      |       ||  _   |   |   |  |     |_
+#          |       ||      |       | ||_|| || |_|   |  |   |  |    _  |
+#          |_______||____||_|      |_|   |_||_______|  |___|  |___| |_|
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This script is produced within the scope of Work Package 5, named Simulation 
+# platform, under SIGMA3 project. For more detailed information about 
+# the project, please visit to https://sigma-programs.com/.
+# -----------------------------------------------------------------------------
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+# coding: utf-8
+
+"""
+module :mod:`openquake.man.ses_utils.ses_source` provides a function to construct 
+OQ Engine area source instance.
+"""
+
+import numpy as np
+
+from openquake.hazardlib.pmf import PMF
+from openquake.hazardlib.tom import PoissonTOM
+from openquake.hazardlib.source import AreaSource
+from openquake.hazardlib.geo.nodalplane import NodalPlane
+from openquake.hazardlib.scalerel import get_available_area_scalerel
+from openquake.man.ses_utils.ses_geo import get_oq_polygons
+
+
+def get_area_source(
+            mfd,
+            polygon_fname,
+            hdd=None,
+            grid_spacing=10.
+        ):
+    """
+    Returns an OQ Engine area source instance
+
+    :param mfd:
+        An instance of OQ Engine magnitude-frequency distribution class
+    :param polygon_fname:
+        An instance of a OQ Engine polygon class. See :class:`openquake.hazardlib.geo.Polygon`
+    :param hdd:
+        An instance of a PMF class. See  :class:`openquake.hazardlib.pmf.PMF`
+    :param grid_spacing:
+        Grid spacing used for area source discretization.
+    """
+
+    # Magnitude scaling-relationship
+    msrs = get_available_area_scalerel()
+    msr = msrs['WC1994']()
+
+    # Temporal occurrence model
+    time_span = 1.0
+    tom = PoissonTOM(time_span)
+
+    # Nodal plane distribution
+    npd = PMF([(1.0, NodalPlane(0.0, 90.0, 0.0))])
+
+    # Upper and lower seismogenic depth
+    usd = 0
+    lsd = 15.0
+
+    if hdd is None:
+        hdd = PMF([(1.0, 7.5)])
+    else:
+        usd = np.min([v[1] for v in hdd.data])
+        lsd = np.max([v[1] for v in hdd.data])
+
+    # Get geometry
+    polys = get_oq_polygons(polygon_fname)
+    if len(polys) == 0:
+        raise ValueError('The file does not contain a polygon')
+    elif len(polys) > 1:
+        raise ValueError(f'The file contains {len(polys)} polygons')
+
+    # Area source
+    src = AreaSource(
+        source_id = 'test',
+        name = 'test',
+        tectonic_region_type = 'Undef',
+        mfd = mfd,
+        rupture_mesh_spacing = 5.0,
+        magnitude_scaling_relationship = msr,
+        rupture_aspect_ratio = 1.0,
+        temporal_occurrence_model = tom,
+        upper_seismogenic_depth = usd,
+        lower_seismogenic_depth = lsd,
+        nodal_plane_distribution = npd,
+        hypocenter_distribution = hdd,
+        polygon = polys[0],
+        area_discretization = grid_spacing
+    )
+
+    return src

--- a/openquake/man/tests/ses_utils/ses_cat_test.py
+++ b/openquake/man/tests/ses_utils/ses_cat_test.py
@@ -39,7 +39,7 @@ import numpy as np
 import tempfile
 import shutil
 
-from openquake.man.ses_cat import (
+from openquake.man.ses_utils.ses_cat import (
     merge_ses_event_rupture, 
     add_random_datetime, 
     convert_to_hmtk,
@@ -136,4 +136,3 @@ class TestSESCatalogue(unittest.TestCase):
         saved_df = pd.read_csv(result_path)
         self.assertEqual(len(saved_df), 10)
         self.assertEqual(saved_df.columns[0], "longitude")
-

--- a/openquake/man/tests/ses_utils/ses_generator_test.py
+++ b/openquake/man/tests/ses_utils/ses_generator_test.py
@@ -28,21 +28,22 @@
 # vim: tabstop=4 shiftwidth=4 softtabstop=4
 # coding: utf-8
 
-import os
-import json
-import unittest
-import tempfile
-import shutil
 import numpy as np
-from pathlib import Path
+import json
+import os
+import shutil
+import tempfile
+import unittest
 
 from openquake.hazardlib.mfd import TruncatedGRMFD
 from openquake.hazardlib.pmf import PMF
 from openquake.hazardlib.source.rupture import EBRupture
-from openquake.man.ses_utils.ses_generator import ses_from_area_source
+from openquake.man.ses_utils.ses_generator import prepare_source_for_sampling, ses_from_area_source
+from openquake.man.ses_utils.ses_source import get_area_source
+
 
 """
-Testing the function in the ses_generator.py
+Tests for the functions in ses_generator.py.
 """
 
 class TestSESGenerator(unittest.TestCase):
@@ -54,49 +55,71 @@ class TestSESGenerator(unittest.TestCase):
 
     def setUp(self):
         self.test_dir = tempfile.mkdtemp()
-        self.poly_file = os.path.join(self.test_dir, 'test_area_source.geojson')
-        
-        poly_json = {
+        self.poly_file = os.path.join(self.test_dir, "test_area_source.geojson")
+
+        polygon_geojson = {
             "type": "FeatureCollection",
             "name": "test_area",
-            "features": [{
-                "type": "Feature",
-                "geometry": {
-                    "type": "Polygon",
-                    "coordinates": [[
-                        [10.0, 40.0], 
-                        [10.0, 45.0], 
-                        [15.0, 45.0], 
-                        [15.0, 40.0], 
-                        [10.0, 40.0]
-                    ]]
-                },
-                "properties": {}
-            }]
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [
+                            [
+                                [10.0, 40.0],
+                                [10.0, 45.0],
+                                [15.0, 45.0],
+                                [15.0, 40.0],
+                                [10.0, 40.0],
+                            ]
+                        ],
+                    },
+                    "properties": {},
+                }
+            ],
         }
-        
-        with open(self.poly_file, 'w') as f:
-            json.dump(poly_json, f)
+
+        with open(self.poly_file, "w", encoding="utf-8") as file:
+            json.dump(polygon_geojson, file)
+
+        self.mfd = TruncatedGRMFD(min_mag=4.0, max_mag=6.5, bin_width=0.1, a_val=4.5, b_val=1.0)
+        self.hdd = PMF([(0.3, 5.0), (0.7, 10.0)])
 
     def tearDown(self):
         shutil.rmtree(self.test_dir)
 
+    def test_prepare_source_for_sampling(self):
+        """ Tests source objects receive metadata required by BaseSeismicSource.sample_ruptures(). """
+        src = get_area_source(self.mfd, polygon_fname=self.poly_file, hdd=self.hdd)
+        self.assertIsNone(src.sampling)
+        prepared_src = prepare_source_for_sampling(src)
+        self.assertIs(prepared_src, src)
+
+        self.assertEqual(src.id, 0)
+        self.assertEqual(src.offset, 0)
+        self.assertEqual(src.smweight, 1.0)
+
+        self.assertIsInstance(src.sampling, dict)
+        self.assertIn("samples", src.sampling)
+        self.assertIn("trt_smr", src.sampling)
+
+        np.testing.assert_array_equal(src.sampling["samples"], np.array([1], dtype=np.uint32))
+        np.testing.assert_array_equal(src.sampling["trt_smr"], np.array([0], dtype=np.uint32))
+
+        self.assertEqual(src.sampling["samples"].dtype, np.dtype(np.uint32))
+        self.assertEqual(src.sampling["trt_smr"].dtype, np.dtype(np.uint32))
+
     def test_ses_from_area_source_full_simulation(self):
-        """ Testing the complete simulation pipeline executes successfully """
-        np.random.seed(42)
-        mfd = TruncatedGRMFD(4.0, 6.5, 0.1, 6.5, 1.0)
-        hdd = PMF([(0.3, 5.0), (0.7, 10.0)])
-        
-        ses = ses_from_area_source(self.poly_file, mfd, hdd)
-        self.assertIsNotNone(ses, "ses_from_area_source function returned None!")
+        """ Test that the complete SES simulation pipeline executes successfully. """
+        ses = ses_from_area_source(self.poly_file, self.mfd, self.hdd)
+
         self.assertIsInstance(ses, list)
-        self.assertGreater(len(ses), 0)
-        
-        # Verify that the objects inside the list are EBRupture instances
-        first_event = ses[0]
-        self.assertIsInstance(first_event, EBRupture)
-        
-        # Data integrity check: simulated magnitudes stay within the MFD bounds [4.0, 6.5]
-        magnitudes = [e.mag for e in ses]
-        self.assertTrue(all(4.0 <= m <= 6.5 for m in magnitudes))
-        
+        self.assertGreater(len(ses), 0, "ses_from_area_source returned an empty SES.")
+
+        for event in ses:
+            self.assertIsInstance(event, EBRupture)
+
+        mags = [event.mag for event in ses]
+
+        self.assertTrue(all(4.0 <= mag <= 6.5 for mag in mags), "At least one simulated magnitude is outside the MFD bounds.")

--- a/openquake/man/tests/ses_utils/ses_generator_test.py
+++ b/openquake/man/tests/ses_utils/ses_generator_test.py
@@ -39,7 +39,7 @@ from openquake.hazardlib.mfd import TruncatedGRMFD
 from openquake.hazardlib.pmf import PMF
 from openquake.hazardlib.source.rupture import EBRupture
 from openquake.man.ses_utils.ses_generator import prepare_source_for_sampling, ses_from_area_source
-from openquake.man.ses_utils.ses_source import get_area_source
+from openquake.man.ses_utils.ses_source import make_area_source
 
 
 """
@@ -91,9 +91,9 @@ class TestSESGenerator(unittest.TestCase):
 
     def test_prepare_source_for_sampling(self):
         """ Tests source objects receive metadata required by BaseSeismicSource.sample_ruptures(). """
-        src = get_area_source(self.mfd, polygon_fname=self.poly_file, hdd=self.hdd)
+        src = make_area_source(self.mfd, polygon_fname=self.poly_file, hdd=self.hdd)
         self.assertIsNone(src.sampling)
-        prepared_src = prepare_source_for_sampling(src)
+        prepared_src = prepare_source_for_sampling(src, samples=2)
         self.assertIs(prepared_src, src)
 
         self.assertEqual(src.id, 0)
@@ -104,7 +104,7 @@ class TestSESGenerator(unittest.TestCase):
         self.assertIn("samples", src.sampling)
         self.assertIn("trt_smr", src.sampling)
 
-        np.testing.assert_array_equal(src.sampling["samples"], np.array([1], dtype=np.uint32))
+        np.testing.assert_array_equal(src.sampling["samples"], np.array([2], dtype=np.uint32))
         np.testing.assert_array_equal(src.sampling["trt_smr"], np.array([0], dtype=np.uint32))
 
         self.assertEqual(src.sampling["samples"].dtype, np.dtype(np.uint32))
@@ -123,3 +123,22 @@ class TestSESGenerator(unittest.TestCase):
         mags = [event.mag for event in ses]
 
         self.assertTrue(all(4.0 <= mag <= 6.5 for mag in mags), "At least one simulated magnitude is outside the MFD bounds.")
+
+    def test_ses_from_area_source_with_custom_sampling_parameters(self):
+        """
+        Test that SES sampling parameters can be provided explicitly.
+        """
+        ses = ses_from_area_source(
+            self.poly_file,
+            self.mfd,
+            self.hdd,
+            num_ses=50,
+            ses_seed=42,
+            samples=2,
+        )
+
+        self.assertIsInstance(ses, list)
+        self.assertGreater(len(ses), 0)
+
+        for event in ses:
+            self.assertIsInstance(event, EBRupture)

--- a/openquake/man/tests/ses_utils/ses_generator_test.py
+++ b/openquake/man/tests/ses_utils/ses_generator_test.py
@@ -1,0 +1,98 @@
+# ------------------- The OpenQuake Model Building Toolkit --------------------
+# Copyright (C) 2026 GEM Foundation and Électricité de France
+#           _______  _______        __   __  _______  _______  ___   _
+#          |       ||       |      |  |_|  ||  _    ||       ||   | | |
+#          |   _   ||   _   | ____ |       || |_|   ||_     _||   |_| |
+#          |  | |  ||  | |  ||____||       ||       |  |   |  |      _|
+#          |  |_|  ||  |_|  |      |       ||  _   |   |   |  |     |_
+#          |       ||      |       | ||_|| || |_|   |  |   |  |    _  |
+#          |_______||____||_|      |_|   |_||_______|  |___|  |___| |_|
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This script is produced within the scope of Work Package 5, named Simulation 
+# platform, under SIGMA3 project. For more detailed information about 
+# the project, please visit to https://sigma-programs.com/.
+# -----------------------------------------------------------------------------
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+# coding: utf-8
+
+import os
+import json
+import unittest
+import tempfile
+import shutil
+import numpy as np
+
+from openquake.hazardlib.mfd import TruncatedGRMFD
+from openquake.hazardlib.pmf import PMF
+from openquake.hazardlib.source.rupture import EBRupture
+from openquake.man.ses_utils.ses_generator import ses_from_area_source
+
+"""
+Testing the function in the ses_generator.py
+"""
+
+class TestSESGenerator(unittest.TestCase):
+    """
+    Integration test for the ses_from_area_source function. Runs a simulation 
+    by spinning up real OpenQuake objects and reading from a temporary 
+    GeoJSON file.
+    """
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.poly_file = os.path.join(self.test_dir, 'test_area_source.geojson')
+        
+        poly_json = {
+            "type": "FeatureCollection",
+            "name": "test_area",
+            "features": [{
+                "type": "Feature",
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [[
+                        [4.0, 44.0], 
+                        [4.0, 46.0], 
+                        [6.0, 46.0], 
+                        [6.0, 44.0], 
+                        [4.0, 44.0]
+                    ]]
+                },
+                "properties": {}
+            }]
+        }
+        
+        with open(self.poly_file, 'w') as f:
+            json.dump(poly_json, f)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_ses_from_area_source_full_simulation(self):
+        """ Testing the complete simulation pipeline executes successfully """
+        mfd = TruncatedGRMFD(4.0, 7.0, 0.1, 4.5, 1.0)
+        hdd = PMF([(0.3, 5.0), (0.7, 10.0)])
+        
+        ses = ses_from_area_source(self.poly_file, mfd, hdd)
+        self.assertIsInstance(ses, list)
+        self.assertGreater(len(ses), 0)
+        
+        # Verify that the objects inside the list are EBRupture instances
+        first_event = ses[0]
+        self.assertIsInstance(first_event, EBRupture)
+        
+        # Data integrity check: simulated magnitudes stay within the MFD bounds [4.0, 7.0]
+        magnitudes = [e.mag for e in ses]
+        self.assertTrue(all(4.0 <= m <= 7.0 for m in magnitudes))

--- a/openquake/man/tests/ses_utils/ses_generator_test.py
+++ b/openquake/man/tests/ses_utils/ses_generator_test.py
@@ -34,6 +34,7 @@ import unittest
 import tempfile
 import shutil
 import numpy as np
+from pathlib import Path
 
 from openquake.hazardlib.mfd import TruncatedGRMFD
 from openquake.hazardlib.pmf import PMF
@@ -63,11 +64,11 @@ class TestSESGenerator(unittest.TestCase):
                 "geometry": {
                     "type": "Polygon",
                     "coordinates": [[
-                        [4.0, 44.0], 
-                        [4.0, 46.0], 
-                        [6.0, 46.0], 
-                        [6.0, 44.0], 
-                        [4.0, 44.0]
+                        [10.0, 40.0], 
+                        [10.0, 45.0], 
+                        [15.0, 45.0], 
+                        [15.0, 40.0], 
+                        [10.0, 40.0]
                     ]]
                 },
                 "properties": {}
@@ -82,10 +83,12 @@ class TestSESGenerator(unittest.TestCase):
 
     def test_ses_from_area_source_full_simulation(self):
         """ Testing the complete simulation pipeline executes successfully """
-        mfd = TruncatedGRMFD(4.0, 7.0, 0.1, 4.5, 1.0)
+        np.random.seed(42)
+        mfd = TruncatedGRMFD(4.0, 6.5, 0.1, 6.5, 1.0)
         hdd = PMF([(0.3, 5.0), (0.7, 10.0)])
         
         ses = ses_from_area_source(self.poly_file, mfd, hdd)
+        self.assertIsNotNone(ses, "ses_from_area_source function returned None!")
         self.assertIsInstance(ses, list)
         self.assertGreater(len(ses), 0)
         
@@ -93,6 +96,7 @@ class TestSESGenerator(unittest.TestCase):
         first_event = ses[0]
         self.assertIsInstance(first_event, EBRupture)
         
-        # Data integrity check: simulated magnitudes stay within the MFD bounds [4.0, 7.0]
+        # Data integrity check: simulated magnitudes stay within the MFD bounds [4.0, 6.5]
         magnitudes = [e.mag for e in ses]
-        self.assertTrue(all(4.0 <= m <= 7.0 for m in magnitudes))
+        self.assertTrue(all(4.0 <= m <= 6.5 for m in magnitudes))
+        

--- a/openquake/man/tests/ses_utils/ses_generator_test.py
+++ b/openquake/man/tests/ses_utils/ses_generator_test.py
@@ -83,8 +83,9 @@ class TestSESGenerator(unittest.TestCase):
     def test_ses_from_area_source_full_simulation(self):
         """ Testing the complete simulation pipeline executes successfully """
         mfd = TruncatedGRMFD(4.0, 7.0, 0.1, 4.5, 1.0)
+        hdd = PMF([(0.3, 5.0), (0.7, 10.0)])
         
-        ses = ses_from_area_source(self.poly_file, mfd, hdd=None)
+        ses = ses_from_area_source(self.poly_file, mfd, hdd)
         self.assertIsInstance(ses, list)
         self.assertGreater(len(ses), 0)
         

--- a/openquake/man/tests/ses_utils/ses_generator_test.py
+++ b/openquake/man/tests/ses_utils/ses_generator_test.py
@@ -83,9 +83,8 @@ class TestSESGenerator(unittest.TestCase):
     def test_ses_from_area_source_full_simulation(self):
         """ Testing the complete simulation pipeline executes successfully """
         mfd = TruncatedGRMFD(4.0, 7.0, 0.1, 4.5, 1.0)
-        hdd = PMF([(0.3, 5.0), (0.7, 10.0)])
         
-        ses = ses_from_area_source(self.poly_file, mfd, hdd)
+        ses = ses_from_area_source(self.poly_file, mfd, hdd=None)
         self.assertIsInstance(ses, list)
         self.assertGreater(len(ses), 0)
         

--- a/openquake/man/tests/ses_utils/ses_geo_test.py
+++ b/openquake/man/tests/ses_utils/ses_geo_test.py
@@ -1,0 +1,78 @@
+# ------------------- The OpenQuake Model Building Toolkit --------------------
+# Copyright (C) 2026 GEM Foundation and Électricité de France
+#           _______  _______        __   __  _______  _______  ___   _
+#          |       ||       |      |  |_|  ||  _    ||       ||   | | |
+#          |   _   ||   _   | ____ |       || |_|   ||_     _||   |_| |
+#          |  | |  ||  | |  ||____||       ||       |  |   |  |      _|
+#          |  |_|  ||  |_|  |      |       ||  _   |   |   |  |     |_
+#          |       ||      |       | ||_|| || |_|   |  |   |  |    _  |
+#          |_______||____||_|      |_|   |_||_______|  |___|  |___| |_|
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This script is produced within the scope of Work Package 5, named Simulation 
+# platform, under SIGMA3 project. For more detailed information about 
+# the project, please visit to https://sigma-programs.com/.
+# -----------------------------------------------------------------------------
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+# coding: utf-8
+
+import os
+import json
+import unittest
+import tempfile
+import shutil
+from openquake.man.ses_utils.ses_geo import get_oq_polygons
+from openquake.hazardlib.geo import Polygon
+
+"""
+Testing the function in the ses_geo.py
+"""
+
+class TestSESGeo(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.poly_file = os.path.join(self.test_dir, 'test_poly.geojson')
+        
+        poly_json = {
+            "type": "FeatureCollection",
+            "features": [{
+                "type": "Feature",
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [[[4.0, 44.0], [4.0, 45.0], [5.0, 45.0], [5.0, 44.0], [4.0, 44.0]]]
+                },
+                "properties": {}
+            }]
+        }
+        with open(self.poly_file, 'w') as f:
+            json.dump(poly_json, f)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_get_oq_polygons_real_file(self):
+        """ Testing the GeoJSON file containing a polygon is correctly converted to an OQ Polygon instance """
+        polygons = get_oq_polygons(self.poly_file)
+        
+        self.assertEqual(len(polygons), 1)
+        self.assertIsInstance(polygons[0], Polygon)
+
+    def test_get_oq_polygons_file_not_found_error(self):
+        """ Testing that an IOError is explicitly raised when the specified path does not exist """
+        fake_path = os.path.join(self.test_dir, 'non_existent_file.geojson')
+        
+        with self.assertRaises(IOError):
+            get_oq_polygons(fake_path)
+    

--- a/openquake/man/tests/ses_utils/ses_source_test.py
+++ b/openquake/man/tests/ses_utils/ses_source_test.py
@@ -1,0 +1,77 @@
+# ------------------- The OpenQuake Model Building Toolkit --------------------
+# Copyright (C) 2026 GEM Foundation and Électricité de France
+#           _______  _______        __   __  _______  _______  ___   _
+#          |       ||       |      |  |_|  ||  _    ||       ||   | | |
+#          |   _   ||   _   | ____ |       || |_|   ||_     _||   |_| |
+#          |  | |  ||  | |  ||____||       ||       |  |   |  |      _|
+#          |  |_|  ||  |_|  |      |       ||  _   |   |   |  |     |_
+#          |       ||      |       | ||_|| || |_|   |  |   |  |    _  |
+#          |_______||____||_|      |_|   |_||_______|  |___|  |___| |_|
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This script is produced within the scope of Work Package 5, named Simulation 
+# platform, under SIGMA3 project. For more detailed information about 
+# the project, please visit to https://sigma-programs.com/.
+# -----------------------------------------------------------------------------
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+# coding: utf-8
+
+import os
+import json
+import unittest
+import tempfile
+import shutil
+from openquake.man.ses_utils.ses_source import get_area_source
+from openquake.hazardlib.mfd import TruncatedGRMFD
+from openquake.hazardlib.pmf import PMF
+from openquake.hazardlib.source import AreaSource
+
+"""
+Testing the function in the ses_source.py
+"""
+
+class TestSESSource(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.poly_file = os.path.join(self.test_dir, 'test_poly.geojson')
+        
+        poly_json = {
+            "type": "FeatureCollection",
+            "features": [{
+                "type": "Feature",
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [[[4.0, 44.0], [4.0, 45.0], [5.0, 45.0], [5.0, 44.0], [4.0, 44.0]]]
+                },
+                "properties": {}
+            }]
+        }
+        with open(self.poly_file, 'w') as f:
+            json.dump(poly_json, f)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_get_area_source_real_objects(self):
+        """ Testing integration using MFD and PMF objects """
+        mfd = TruncatedGRMFD(4.0, 7.0, 0.1, 4.5, 1.0)
+        hdd = PMF([(0.3, 5.0), (0.7, 10.0)])
+        
+        src = get_area_source(mfd, self.poly_file, hdd=hdd)
+        
+        self.assertIsInstance(src, AreaSource)
+        self.assertEqual(src.upper_seismogenic_depth, 5.0)
+        self.assertEqual(src.lower_seismogenic_depth, 10.0)
+        

--- a/openquake/man/tests/ses_utils/ses_source_test.py
+++ b/openquake/man/tests/ses_utils/ses_source_test.py
@@ -33,7 +33,7 @@ import json
 import unittest
 import tempfile
 import shutil
-from openquake.man.ses_utils.ses_source import get_area_source
+from openquake.man.ses_utils.ses_source import make_area_source
 from openquake.hazardlib.mfd import TruncatedGRMFD
 from openquake.hazardlib.pmf import PMF
 from openquake.hazardlib.source import AreaSource
@@ -64,14 +64,14 @@ class TestSESSource(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.test_dir)
 
-    def test_get_area_source_real_objects(self):
+    def test_make_area_source_real_objects(self):
         """ Testing integration using MFD and PMF objects """
         mfd = TruncatedGRMFD(4.0, 7.0, 0.1, 4.5, 1.0)
         hdd = PMF([(0.3, 5.0), (0.7, 10.0)])
         
-        src = get_area_source(mfd, self.poly_file, hdd=hdd)
+        src = make_area_source(mfd, self.poly_file, hdd=hdd)
         
         self.assertIsInstance(src, AreaSource)
-        self.assertEqual(src.upper_seismogenic_depth, 5.0)
-        self.assertEqual(src.lower_seismogenic_depth, 10.0)
+        self.assertEqual(src.upper_seismogenic_depth, 0.0)
+        self.assertEqual(src.lower_seismogenic_depth, 15.0)
         


### PR DESCRIPTION
This PR introduces utils for simple SES generation. Below, you might see brief explanations of scripts.

**ses_geo.py**
- Provides a function for parsing geospatial data files (e.g., GeoJSON, Shapefile) and converting their geometries into OQ Engine polygon instances.

**ses_source.py**
- Provides a function to construct OQ Engine area source instance by combining MFD, PMF, and geometries.

**ses_generator.py**
- Provides a function to generate 1000 Stochastic Event Set (SES) by sampling earthquake ruptures from configured seismic sources using Monte Carlo sampling.