### PR TITLE
add dists from rup option for staiton data

### DIFF
--- a/docsrc/contents/smt.rst
+++ b/docsrc/contents/smt.rst
@@ -500,7 +500,8 @@ Comparing GMPEs
        .. image:: /contents/smt_images/TrellisPlots.png
    
    The user can also automatically plot observations from a ground-motion flatfile against the GMPE attenuation curves by specifying an optional argument of ``obs_data_fname``, which must be the path to a CSV file
-   containing a GEM-format ground-motion flatfile. An example of the GEM flatfile format can be found within ``openquake\smt\tests\comparison\data\inputs\gem_flatfile_sample.csv``.
+   containing a GEM-format ground-motion flatfile. An example of the GEM flatfile format can be found within ``openquake\smt\tests\comparison\data\inputs\gem_flatfile_sample.csv``. If ``station_dists_from_rup`` is
+   ``True``, then the distances used for the plotting of the station data are computed from the same finite rupture used for the GMMs, and if otherwise then the distances provided in the flatfile are used instead.
 
 4. Spectra Plots
 

--- a/openquake/smt/comparison/compare_gmpes.py
+++ b/openquake/smt/comparison/compare_gmpes.py
@@ -140,7 +140,11 @@ class Configurations(object):
         "z2pt5": -999, # Compute param using each GMM's vs30 to z2pt5
         "up_or_down_dip": 1, # Assume site is up-dip
         "volc_back_arc": False, # Asssume site is not in back-arc
-        "eshm20_region": 0} # Assume default region for ESHM version of K20 GMM
+        "eshm20_region": 0, # Assume default region for ESHM version of K20 GMM
+        "station_dists_from_rup": False} # If True, compute station distances of
+                                         # plotted flatfile observations from the
+                                         # OQ rupture instead of using the
+                                         # flatfile-stored distances
 
         # Get site params
         self.vs30 = config_file['site_properties']['vs30'] # Must be provided
@@ -417,9 +421,12 @@ def plot_trellis(filename, output_directory, obs_data_fname=None):
         --> Within +/- 150 m/s of specified Vs30
         --> NOTE: The user must provide a geographically and tectonic
             region filtered flatfile (this filtering is not done here).
-    """ 
+        --> NOTE: If the optional "station_dists_from_rup" flag is True the plotted
+            station distances are computed from the OQ rupture rather than
+            read from the flatfile.
+    """
     config = Configurations(filename)
-    
+
     store_gmm_curves = plot_trellis_util(config, output_directory, obs_data_fname)
     
     return store_gmm_curves
@@ -446,6 +453,9 @@ def plot_spectra(filename, output_directory, obs_spectra_fname=None, obs_data_fn
             distance type specified in the toml file.
         --> NOTE: The user must provide a geographically and tectonic
             region filtered flatfile (this filtering is not done here).
+        --> NOTE: If the optional "station_dists_from_rup" flag is True the plotted
+            station distances are computed from the OQ rupture rather than
+            read from the flatfile.
     """
     config = Configurations(filename)
 

--- a/openquake/smt/comparison/utils_compare_gmpes.py
+++ b/openquake/smt/comparison/utils_compare_gmpes.py
@@ -29,9 +29,13 @@ from scipy import interpolate
 
 from openquake.hazardlib.imt import PGA, SA
 from openquake.smt.comparison.sammons import sammon
-from openquake.smt.utils import clean_gmm_label, COLORS, GEM_FF_MAPPINGS
-from openquake.smt.comparison.utils_gmpes import (get_imtl_unit, 
+from openquake.smt.utils import (clean_gmm_label,
+                                 compute_dist_from_rup,
+                                 COLORS,
+                                 GEM_FF_MAPPINGS)
+from openquake.smt.comparison.utils_gmpes import (get_imtl_unit,
                                                   att_curves,
+                                                  get_rup,
                                                   get_rup_pars,
                                                   gmpe_check)
 
@@ -105,12 +109,23 @@ def plot_trellis_util(config, output_directory, obs_data_fname):
                                                      config.dip,
                                                      config.rake,
                                                      config.aratio,
-                                                     config.trt) 
-            
+                                                     config.trt)
+
             # If plotting data get the appropriate subset
             if data is not None:
+                # Get the rupture for computing distances from if required
+                if config.station_dists_from_rup:
+                    if config.rup is not None:
+                        rup_obs = config.rup
+                    else:
+                        rup_obs = get_rup(
+                            mag, config.lon, config.lat, depth_g, ztor_g, aratio_g,
+                            strike_g, dip_g, config.rake, config.trt)
+                else:
+                    rup_obs = None
                 subset = filter_flatfile_trellis(
-                    data, imt, mag, depth_g, config.vs30, config.dist_type)
+                    data, imt, mag, depth_g, config.vs30, config.dist_type,
+                    rup=rup_obs)
             else:
                 subset = None
 
@@ -343,8 +358,19 @@ def plot_spectra_util(config, output_directory, obs_spectra_fname, obs_data_fnam
 
             # If plotting data get the appropriate subset
             if data is not None:
+                # Get the rupture for computing distances from if required
+                if config.station_dists_from_rup:
+                    if config.rup is not None:
+                        rup_obs = config.rup
+                    else:
+                        rup_obs = get_rup(
+                            mag, config.lon, config.lat, depth_g, ztor_g, aratio_g,
+                            strike_g, dip_g, config.rake, config.trt)
+                else:
+                    rup_obs = None
                 subset = filter_flatfile_spectra(
-                    data, imt_list, mag, depth_g, config.vs30, dist, config.dist_type)
+                    data, imt_list, mag, depth_g, config.vs30, dist, config.dist_type,
+                    rup=rup_obs)
             else:
                 subset = None
 
@@ -1245,10 +1271,14 @@ def update_trellis_plots(mag, imt, m, i, dep, vs30, minR, maxR, r_vals, imt_list
     pyplot.loglog()
     
 
-def filter_flatfile_trellis(data, imt, mag, depth, vs30, dist_type):
+def filter_flatfile_trellis(data, imt, mag, depth, vs30, dist_type, rup=None):
     """
     Filter the dataframe of the provided flatfile for the given imt,
     magnitude, focal depth and vs30 for use in trellis plotting.
+
+    NOTE: If "rup" is provided, the flatfile distances of the retained
+    records are replaced with distances computed from the given rupture
+    to each station.
 
     NOTE: We return RotD50 values which have consistency with OQ units.
     """
@@ -1264,6 +1294,12 @@ def filter_flatfile_trellis(data, imt, mag, depth, vs30, dist_type):
 
     # Convert from flatfile units to those of GMPEs in OQ for given IMT
     subset[imt_col] = subset[imt_col] * GEM_FF_MAPPINGS[imt]["conv_factor"]
+
+    # Override flatfile distances with distances computed from the rupture
+    if rup is not None and len(subset) > 0:
+        subset[GEM_FF_MAPPINGS[dist_type]] = compute_dist_from_rup(
+            dist_type, rup, subset["st_longitude"].values,
+            subset["st_latitude"].values)
 
     # End of flatfile filtering
     if len(subset) > 0:
@@ -1485,16 +1521,27 @@ def raise_spectra_dist_error(dist, dist_type, r_vals):
                      f"shaking scenario (min = {r_min} km, max = {r_max} km)")
 
 
-def filter_flatfile_spectra(data, imts, mag, depth, vs30, dist, dist_type):
+def filter_flatfile_spectra(data, imts, mag, depth, vs30, dist, dist_type, rup=None):
     """
     Filter the dataframe of the provided flatfile for the given imt,
     magnitude, focal depth, vs30 AND distance type for use in spectra
     plotting.
 
+    NOTE: If "rup" is provided, distances used for the distance-based
+    filter (and stored in the returned subset) are computed from the
+    given rupture to each station instead of read from the flatfile.
+
     NOTE: We return RotD50 values which have consistency with OQ units.
     """
     # Filter first by magnitude, depth and vs30 first
     subset = filter_flatfile(data, mag, depth, vs30, dist_type)
+
+    # Override flatfile distances with distances computed from the rupture
+    dcol = GEM_FF_MAPPINGS[dist_type]
+    if rup is not None and len(subset) > 0:
+        subset[dcol] = compute_dist_from_rup(
+            dist_type, rup, subset["st_longitude"].values,
+            subset["st_latitude"].values)
 
     # Filter by distance (smaller window when closer to source)
     if dist <= 50:
@@ -1503,7 +1550,6 @@ def filter_flatfile_spectra(data, imts, mag, depth, vs30, dist, dist_type):
         dlim = DIST_LIM_MID
     else:
         dlim = DIST_LIM_MAX
-    dcol = GEM_FF_MAPPINGS[dist_type]
     subset = subset.loc[
         subset[dcol].between(dist - dlim, dist + dlim)].reset_index(drop=True)
     

--- a/openquake/smt/tests/comparison/data/inputs/comparison_test.toml
+++ b/openquake/smt/tests/comparison/data/inputs/comparison_test.toml
@@ -16,6 +16,7 @@ z2pt5 = 0.57  # (km) - if -999 compute from each GMM's own vs30 to z2pt5 relatio
 up_or_down_dip = 1 # 1 = up-dip, 0 = down-dip
 volc_back_arc = false # true or false
 eshm20_region = 0 # Residual attenuation cluster to use for KothaEtAl2020ESHM20
+dists_from_rup = true # Use dists from same rup used for GMMs (default of false means dists in flatfile are used)
 
 [source_properties] # Characterise EQ as finite rupture
 lon = 0

--- a/openquake/smt/utils.py
+++ b/openquake/smt/utils.py
@@ -26,6 +26,8 @@ from scipy.integrate import cumulative_trapezoid
 from shapely.geometry import MultiPolygon
 
 from openquake.hazardlib.geo import PlanarSurface, Point
+from openquake.hazardlib.geo.mesh import Mesh
+from openquake.hazardlib.geo.geodetic import geodetic_distance
 from openquake.hazardlib.source.rupture import BaseRupture
 from openquake.hazardlib.gsim import get_available_gsims
 from openquake.hazardlib.gsim.gmpe_table import GMPETable
@@ -331,6 +333,28 @@ def make_rup(lon,
     rup = BaseRupture(mag, rake, trt, hypoc, srf)
     rup.hypocenter.depth = dep
     return rup
+
+
+def compute_dist_from_rup(dist_type, rup, lons, lats):
+    """
+    Compute the source-to-site distance of the given type from the
+    provided OQ rupture to each of the given station coordinates.
+    """
+    lons = np.asarray(lons, dtype=float)
+    lats = np.asarray(lats, dtype=float)
+    if dist_type == "rrup":
+        return rup.surface.get_min_distance(Mesh(lons, lats))
+    elif dist_type == "rjb":
+        return rup.surface.get_joyner_boore_distance(Mesh(lons, lats))
+    elif dist_type == "repi":
+        return geodetic_distance(
+            rup.hypocenter.longitude, rup.hypocenter.latitude, lons, lats)
+    elif dist_type == "rhypo":
+        epi = geodetic_distance(
+            rup.hypocenter.longitude, rup.hypocenter.latitude, lons, lats)
+        return np.sqrt(epi**2 + rup.hypocenter.depth**2)
+    else:
+        raise ValueError(f"Unsupported dist_type: {dist_type}")
 
 
 def full_dtype_gmm():


### PR DESCRIPTION
The distances to each station can now **optionally** be computed from the same rupture used in the GMMs, rather than having to be provided in the flatfile.

<img width="3388" height="2690" alt="TrellisPlots" src="https://github.com/user-attachments/assets/0a323c98-1f2b-4800-9ab1-3b75fd2e38a5" />
